### PR TITLE
Separate interface from stack in ESP8266

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -68,17 +68,17 @@ int ESP8266Interface::disconnect()
     return 0;
 }
 
-const char *ESP8266Interface::get_ip_address()
+const char* ESP8266Interface::get_ip_address()
 {
     return _esp.getIPAddress();
 }
 
-const char *ESP8266Interface::get_mac_address()
+const char* ESP8266Interface::get_mac_address()
 {
     return _esp.getMACAddress();
 }
 
-NetworkStack * ESP8266Interface::get_stack(void)
+NetworkStack* ESP8266Interface::get_stack(void)
 {
     return &_stack;
 }

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -184,16 +184,16 @@ public:
     /** Get the internally stored MAC address
      *  @return             MAC address of the interface
      */
-    virtual const char *get_mac_address();
+    virtual const char* get_mac_address();
 
 
     /** Get the internally stored IP address
      *  @return             IP address of the interface or null if not yet connected
      */
-    virtual const char *get_ip_address();
+    virtual const char* get_ip_address();
 
 protected:
-    virtual NetworkStack * get_stack(void);
+    virtual NetworkStack* get_stack(void);
 
 private:
     ESP8266 _esp;


### PR DESCRIPTION
Create separate objects for the interface and stack of the ESP8266.
