### PR TITLE
Removed use of C struct initializer in C++

### DIFF
--- a/ESP8266/ATParser/ATParser.cpp
+++ b/ESP8266/ATParser/ATParser.cpp
@@ -325,5 +325,9 @@ bool ATParser::recv(const char *response, ...)
 // oob registration
 void ATParser::oob(const char *prefix, Callback<void()> cb)
 {
-    _oobs.push_back((struct oob){strlen(prefix), prefix, cb});
+    struct oob oob;
+    oob.len = strlen(prefix);
+    oob.prefix = prefix;
+    oob.cb = cb;
+    _oobs.push_back(oob);
 }


### PR DESCRIPTION
Fixes #3

Current flags for mbed-os let gnu-extensions into c++ code. This issue is documented here:
https://github.com/ARMmbed/mbed-os/issues/241

This removes C struct initializers, a gnu-extension.