### PR TITLE
Consolidate the ESP8266Interface and ESP8266Stack

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -26,9 +26,12 @@
 
 // ESP8266Interface implementation
 ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
-    : _esp(tx, rx, debug), _stack(_esp)
+    : _esp(tx, rx, debug)
 {
-    // Do nothing
+    memset(_ids, 0, sizeof(_ids));
+    memset(_cbs, 0, sizeof(_cbs));
+
+    _esp.attach(this, &ESP8266Interface::event);
 }
 
 int ESP8266Interface::connect(
@@ -78,31 +81,13 @@ const char* ESP8266Interface::get_mac_address()
     return _esp.getMACAddress();
 }
 
-NetworkStack* ESP8266Interface::get_stack(void)
-{
-    return &_stack;
-}
-
 struct esp8266_socket {
     int id;
     nsapi_protocol_t proto;
     bool connected;
 };
 
-ESP8266Stack::ESP8266Stack(ESP8266 &esp): _esp(esp)
-{
-    memset(_ids, 0, sizeof(_ids));
-    memset(_cbs, 0, sizeof(_cbs));
-
-    _esp.attach(this, &ESP8266Stack::event);
-};
-
-const char *ESP8266Stack::get_ip_address()
-{
-    return _esp.getIPAddress();
-}
-
-int ESP8266Stack::socket_open(void **handle, nsapi_protocol_t proto)
+int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 {
     // Look for an unused socket
     int id = -1;
@@ -131,7 +116,7 @@ int ESP8266Stack::socket_open(void **handle, nsapi_protocol_t proto)
     return 0;
 }
 
-int ESP8266Stack::socket_close(void *handle)
+int ESP8266Interface::socket_close(void *handle)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     int err = 0;
@@ -146,17 +131,17 @@ int ESP8266Stack::socket_close(void *handle)
     return err;
 }
 
-int ESP8266Stack::socket_bind(void *handle, const SocketAddress &address)
+int ESP8266Interface::socket_bind(void *handle, const SocketAddress &address)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int ESP8266Stack::socket_listen(void *handle, int backlog)
+int ESP8266Interface::socket_listen(void *handle, int backlog)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int ESP8266Stack::socket_connect(void *handle, const SocketAddress &addr)
+int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     _esp.setTimeout(ESP8266_MISC_TIMEOUT);
@@ -170,12 +155,12 @@ int ESP8266Stack::socket_connect(void *handle, const SocketAddress &addr)
     return 0;
 }
     
-int ESP8266Stack::socket_accept(void **handle, void *server)
+int ESP8266Interface::socket_accept(void **handle, void *server)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int ESP8266Stack::socket_send(void *handle, const void *data, unsigned size)
+int ESP8266Interface::socket_send(void *handle, const void *data, unsigned size)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     _esp.setTimeout(ESP8266_SEND_TIMEOUT);
@@ -187,7 +172,7 @@ int ESP8266Stack::socket_send(void *handle, const void *data, unsigned size)
     return size;
 }
 
-int ESP8266Stack::socket_recv(void *handle, void *data, unsigned size)
+int ESP8266Interface::socket_recv(void *handle, void *data, unsigned size)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     _esp.setTimeout(ESP8266_RECV_TIMEOUT);
@@ -200,7 +185,7 @@ int ESP8266Stack::socket_recv(void *handle, void *data, unsigned size)
     return recv;
 }
 
-int ESP8266Stack::socket_sendto(void *handle, const SocketAddress &addr, const void *data, unsigned size)
+int ESP8266Interface::socket_sendto(void *handle, const SocketAddress &addr, const void *data, unsigned size)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     if (!socket->connected) {
@@ -213,20 +198,20 @@ int ESP8266Stack::socket_sendto(void *handle, const SocketAddress &addr, const v
     return socket_send(socket, data, size);
 }
 
-int ESP8266Stack::socket_recvfrom(void *handle, SocketAddress *addr, void *data, unsigned size)
+int ESP8266Interface::socket_recvfrom(void *handle, SocketAddress *addr, void *data, unsigned size)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;    
     return socket_recv(socket, data, size);
 }
 
-void ESP8266Stack::socket_attach(void *handle, void (*callback)(void *), void *data)
+void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), void *data)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;    
     _cbs[socket->id].callback = callback;
     _cbs[socket->id].data = data;
 }
 
-void ESP8266Stack::event() {
+void ESP8266Interface::event() {
     for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
         if (_cbs[i].callback) {
             _cbs[i].callback(_cbs[i].data);

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -17,22 +17,55 @@
 #ifndef ESP8266_INTERFACE_H
 #define ESP8266_INTERFACE_H
 
-#include "WiFiInterface.h"
-#include "NetworkStack.h"
+#include "network-socket/NetworkStack.h"
+#include "network-socket/WiFiInterface.h"
 #include "ESP8266.h"
+
 
 #define ESP8266_SOCKET_COUNT 5
 
-/** ESP8266Stack class
+/** ESP8266Interface class
  *  Implementation of the NetworkStack for the ESP8266
  */
-class ESP8266Stack : public NetworkStack
+class ESP8266Interface : public NetworkStack, public WiFiInterface
 {
 public:
+    /** ESP8266Interface lifetime
+     * @param tx        TX pin
+     * @param rx        RX pin
+     * @param debug     Enable debugging
+     */
+    ESP8266Interface(PinName tx, PinName rx, bool debug = false);
+
+    /** Start the interface
+     *
+     *  Attempts to connect to a WiFi network. If passphrase is invalid,
+     *  NSAPI_ERROR_AUTH_ERROR is returned.
+     *
+     *  @param ssid      Name of the network to connect to
+     *  @param pass      Security passphrase to connect to the network
+     *  @param security  Type of encryption for connection
+     *  @return          0 on success, negative error code on failure
+     */
+    virtual int connect(
+        const char *ssid,
+        const char *pass,
+        nsapi_security_t security = NSAPI_SECURITY_NONE);
+
+    /** Stop the interface
+     *  @return             0 on success, negative on failure
+     */
+    virtual int disconnect();
+
     /** Get the internally stored IP address
      *  @return             IP address of the interface or null if not yet connected
      */
     virtual const char *get_ip_address();
+
+    /** Get the internally stored MAC address
+     *  @return             MAC address of the interface
+     */
+    virtual const char *get_mac_address();
 
 protected:
     /** Open a socket
@@ -134,8 +167,7 @@ protected:
     virtual void socket_attach(void *handle, void (*callback)(void *), void *data);
     
 private:
-    friend class ESP8266Interface;
-    ESP8266 &_esp;
+    ESP8266 _esp;
     bool _ids[ESP8266_SOCKET_COUNT];
 
     void event();
@@ -143,62 +175,7 @@ private:
         void (*callback)(void *);
         void *data;
     } _cbs[ESP8266_SOCKET_COUNT];
-
-    ESP8266Stack(ESP8266 &esp);
 };
 
-
-/** ESP8266Stack class
- *  Implementation of the NetworkInterface for the ESP8266
- */
-class ESP8266Interface : public WiFiInterface
-{
-public:
-    /** ESP8266Interface lifetime
-     * @param tx        TX pin
-     * @param rx        RX pin
-     * @param debug     Enable debugging
-     */
-    ESP8266Interface(PinName tx, PinName rx, bool debug = false);
-
-    /** Start the interface
-     *
-     *  Attempts to connect to a WiFi network. If passphrase is invalid,
-     *  NSAPI_ERROR_AUTH_ERROR is returned.
-     *
-     *  @param ssid      Name of the network to connect to
-     *  @param pass      Security passphrase to connect to the network
-     *  @param security  Type of encryption for connection
-     *  @return          0 on success, negative error code on failure
-     */
-    virtual int connect(
-        const char *ssid,
-        const char *pass,
-        nsapi_security_t security = NSAPI_SECURITY_NONE);
-
-    /** Stop the interface
-     *  @return             0 on success, negative on failure
-     */
-    virtual int disconnect();
-
-    /** Get the internally stored MAC address
-     *  @return             MAC address of the interface
-     */
-    virtual const char* get_mac_address();
-
-
-    /** Get the internally stored IP address
-     *  @return             IP address of the interface or null if not yet connected
-     */
-    virtual const char* get_ip_address();
-
-protected:
-    virtual NetworkStack* get_stack(void);
-
-private:
-    ESP8266 _esp;
-    ESP8266Stack _stack;
-
-};
 
 #endif

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -165,6 +165,15 @@ protected:
      *  @note Callback may be called in an interrupt context.
      */
     virtual void socket_attach(void *handle, void (*callback)(void *), void *data);
+
+    /** Provide access to the NetworkStack object
+     *
+     *  @return The underlying NetworkStack object
+     */
+    virtual NetworkStack *get_stack()
+    {
+        return this;
+    }
     
 private:
     ESP8266 _esp;


### PR DESCRIPTION
**note: no api changes**

Previously an unnecessary dichotomy was introduced between the stack and interface components of the esp8266. The esp8266 provides both operations from a single object and does not benefit from this seperation.

In this situation, multiple inheritance provides a reasonable solution, as the esp8266 class satisfies multiple interfaces.

https://github.com/mbedmicro/mbed/commit/e09565474188b905cada21166118a82e66359217 resolved an ambiguity/protection issue that prevented this consolidation