### PR TITLE
Include "mbed.h" instead of directly network related headers.

### DIFF
--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -17,8 +17,7 @@
 #ifndef ESP8266_INTERFACE_H
 #define ESP8266_INTERFACE_H
 
-#include "network-socket/NetworkStack.h"
-#include "network-socket/WiFiInterface.h"
+#include "mbed.h"
 #include "ESP8266.h"
 
 


### PR DESCRIPTION
This driver does not build anymore against mbed OS master.

Quick workaround is to include "mbed.h" header instead of those specific network headers.
