### PR TITLE
Fix invalid SocketAddress returned from recvfrom

### DIFF
--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -124,6 +124,29 @@ public:
      */
     virtual int scan(WiFiAccessPoint *res, unsigned count);
 
+    /** Translates a hostname to an IP address with specific version
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  @param address  Destination for the host SocketAddress
+     *  @param host     Hostname to resolve
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure
+     */
+    using NetworkInterface::gethostbyname;
+
+    /** Add a domain name server to list of servers to query
+     *
+     *  @param addr     Destination for the host address
+     *  @return         0 on success, negative error code on failure
+     */
+    using NetworkInterface::add_dns_server;
+
 protected:
     /** Open a socket
      *  @param handle       Handle in which to store new socket


### PR DESCRIPTION
In the current version of the firmware, the esp8266 handles UDP in an odd way. Rather than packet based transactions, the esp8266 handles UDP like a connection based protocol.

To return the correct address, the esp8266 just saves the last connection established by UDP. Additionally this patch added the ability of a socket to change connection addresses.

Note: This firmware is still unable to recieve connections from arbitrary hosts.

related issue #15
cc @jankii01 