### PR TITLE
Driver compatible with 2.0 Espressif firmware

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -32,7 +32,7 @@ bool ESP8266::startup(int mode)
     }
 
     bool success = reset()
-        && _parser.send("AT+CWMODE=%d", mode)
+        && _parser.send("AT+CWMODE_CUR=%d", mode)
         && _parser.recv("OK")
         && _parser.send("AT+CIPMUX=1")
         && _parser.recv("OK");
@@ -174,16 +174,20 @@ bool ESP8266::open(const char *type, int id, const char* addr, int port)
     if(id > 4) {
         return false;
     }
-
     return _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d", id, type, addr, port)
         && _parser.recv("OK");
+}
+
+bool ESP8266::dns_lookup(const char* name, char* ip)
+{
+    return _parser.send("AT+CIPDOMAIN=\"%s\"", name) && _parser.recv("+CIPDOMAIN:%s%*[\r]%*[\n]", ip);
 }
 
 bool ESP8266::send(int id, const void *data, uint32_t amount)
 {
     //May take a second try if device is busy
     for (unsigned i = 0; i < 2; i++) {
-        if (_parser.send("AT+CIPSEND=%d,%d", id, amount)
+        if (_parser.send("AT+CIPSENDBUF=%d,%d", id, amount)
             && _parser.recv(">")
             && _parser.write((char*)data, (int)amount) >= 0) {
             return true;

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -116,13 +116,14 @@ public:
      *               see @a nsapi_error
      */
     int scan(WiFiAccessPoint *res, unsigned limit);
+    
     /**Perform a dns query
     *
     * @param name Hostname to resolve
     * @param ip   Buffer to store IP address
     * @return 0 true on success, false on failure
     */
-    bool dns_lookup(const char* name, char* ip);
+    bool dns_lookup(const char *name, char *ip);
 
     /**
     * Open a socketed connection

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -116,6 +116,13 @@ public:
      *               see @a nsapi_error
      */
     int scan(WiFiAccessPoint *res, unsigned limit);
+    /**Perform a dns query
+    *
+    * @param name Hostname to resolve
+    * @param ip   Buffer to store IP address
+    * @return 0 true on success, false on failure
+    */
+    bool dns_lookup(const char* name, char* ip);
 
     /**
     * Open a socketed connection

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -77,14 +77,13 @@ nsapi_error_t ESP8266Interface::gethostbyname(const char* name, SocketAddress *a
         return NSAPI_ERROR_OK;
     }
     
-    char* ipbuff = (char*)malloc(256);
+    char* ipbuff = new char[NSAPI_IP_SIZE];
     int ret = 0;
     
-    if(!_esp.dns_lookup(name, ipbuff))
-    {
+    if(!_esp.dns_lookup(name, ipbuff)) {
         ret = NSAPI_ERROR_DEVICE_ERROR;
     }
-    else{
+    else {
         address->set_ip_address(ipbuff);
     }
     free(ipbuff);

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -67,6 +67,30 @@ int ESP8266Interface::connect()
     return NSAPI_ERROR_OK;
 }
 
+nsapi_error_t ESP8266Interface::gethostbyname(const char* name, SocketAddress *address, nsapi_version_t version)
+{
+    if (address->set_ip_address(name)) {
+        if (version != NSAPI_UNSPEC && address->get_ip_version() != version) {
+            return NSAPI_ERROR_DNS_FAILURE;
+        }
+
+        return NSAPI_ERROR_OK;
+    }
+    
+    char* ipbuff = (char*)malloc(256);
+    int ret = 0;
+    
+    if(!_esp.dns_lookup(name, ipbuff))
+    {
+        ret = NSAPI_ERROR_DEVICE_ERROR;
+    }
+    else{
+        address->set_ip_address(ipbuff);
+    }
+    free(ipbuff);
+    return ret;
+}
+
 int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
 {
     memset(ap_ssid, 0, sizeof(ap_ssid));

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -57,7 +57,21 @@ public:
      */
     virtual int connect(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE,
                                   uint8_t channel = 0);
-
+    
+    /** Translates a hostname to an IP address with specific version
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *
+     *  @param host     Hostname to resolve
+     *  @param address  Destination for the host SocketAddress
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t gethostbyname(const char* name, SocketAddress *address, nsapi_version_t version);
+    
     /** Set the WiFi network credentials
      *
      *  @param ssid      Name of the network to connect to


### PR DESCRIPTION
Here is the AT command set for the new firmware - https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf

Here are the release notes - http://bbs.espressif.com/viewtopic.php?f=46&t=2451#p8029

The new firmware deprecated a few commands, so there are minor changes to AT commands for  configuring WiFi mode and sending data on a socket. 

The new firmware allows dns lookup on ESP8266 module, so I have overriden `gethostbyname` to use this functionality. 

@geky 