### PR TITLE
Ensures ES8266 firmware version up to date

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -24,6 +24,14 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
     _parser.debugOn(debug);
 }
 
+bool ESP8266::check_firmware_version()
+{
+    _parser.send("AT+GMR");
+    int8_t version = 0;
+    bool success = _parser.recv("SDK version: %d", &version) && _parser.recv("OK");
+    return success && (version == 2);
+}
+
 bool ESP8266::startup(int mode)
 {
     //only 3 valid modes

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -24,12 +24,17 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
     _parser.debugOn(debug);
 }
 
-bool ESP8266::check_firmware_version()
+int ESP8266::get_firmware_version()
 {
     _parser.send("AT+GMR");
-    int8_t version = 0;
-    bool success = _parser.recv("SDK version: %d", &version) && _parser.recv("OK");
-    return success && (version == 2);
+    int version;
+    if(_parser.recv("SDK version:%d", &version) && _parser.recv("OK")) {
+        return version;
+    } else { 
+        // Older firmware versions do not prefix the version with "SDK version: "
+        return -1;
+    }
+    
 }
 
 bool ESP8266::startup(int mode)
@@ -39,8 +44,7 @@ bool ESP8266::startup(int mode)
         return false;
     }
 
-    bool success = reset()
-        && _parser.send("AT+CWMODE_CUR=%d", mode)
+    bool success = _parser.send("AT+CWMODE_CUR=%d", mode)
         && _parser.recv("OK")
         && _parser.send("AT+CIPMUX=1")
         && _parser.recv("OK");

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -28,6 +28,13 @@ public:
     ESP8266(PinName tx, PinName rx, bool debug=false);
 
     /**
+    * Check firmware version of ESP8266
+    *
+    * @return true only if ESP8266 firmware > v2
+    */
+    bool check_firmware_version(void);
+    
+    /**
     * Startup the ESP8266
     *
     * @param mode mode of WIFI 1-client, 2-host, 3-both

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -30,9 +30,9 @@ public:
     /**
     * Check firmware version of ESP8266
     *
-    * @return true only if ESP8266 firmware > v2
+    * @return integer firmware version or -1 if firmware query command gives outdated response
     */
-    bool check_firmware_version(void);
+    int get_firmware_version(void);
     
     /**
     * Startup the ESP8266

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -46,8 +46,16 @@ int ESP8266Interface::connect(const char *ssid, const char *pass, nsapi_security
 
 int ESP8266Interface::connect()
 {
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
+    
+    if(!_esp.check_firmware_version()) {
+        debug("ERROR: Firmware incompatible with this driver.\
+               \r\nUpdate to v2.0.0 - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n"); 
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+    
     _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-
+  
     if (!_esp.startup(3)) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -16,12 +16,16 @@
 
 #include <string.h>
 #include "ESP8266Interface.h"
+#include "mbed_debug.h"
 
 // Various timeouts for different ESP8266 operations
 #define ESP8266_CONNECT_TIMEOUT 15000
 #define ESP8266_SEND_TIMEOUT    500
 #define ESP8266_RECV_TIMEOUT    0
 #define ESP8266_MISC_TIMEOUT    500
+
+// Firmware version
+#define ESP8266_VERSION 2
 
 // ESP8266Interface implementation
 ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
@@ -46,16 +50,22 @@ int ESP8266Interface::connect(const char *ssid, const char *pass, nsapi_security
 
 int ESP8266Interface::connect()
 {
+    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
+    
+    if (!_esp.reset()) {
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }   
+ 
     _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     
-    if(!_esp.check_firmware_version()) {
-        debug("ERROR: Firmware incompatible with this driver.\
-               \r\nUpdate to v2.0.0 - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n"); 
+    if (_esp.get_firmware_version() != ESP8266_VERSION) {
+        debug("ESP8266: ERROR: Firmware incompatible with this driver.\
+               \r\nUpdate to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n",ESP8266_VERSION); 
         return NSAPI_ERROR_DEVICE_ERROR;
     }
     
     _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-  
+
     if (!_esp.startup(3)) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -18,6 +18,7 @@
 #define ESP8266_INTERFACE_H
 
 #include "mbed.h"
+#include "mbed_debug.h"
 #include "ESP8266.h"
 
 

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -18,7 +18,6 @@
 #define ESP8266_INTERFACE_H
 
 #include "mbed.h"
-#include "mbed_debug.h"
 #include "ESP8266.h"
 
 


### PR DESCRIPTION
If ESP8266 firmware version is less that v2.0.0, then we print a debug message and return an error from the connect function.  The message directs users to the wiki page for updating the firmware. 