### PR TITLE
readme: Remove quotes from ssid/pass defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mbed add mbed-os
 Now you should be able to run the network tests with `mbed test`:
 ``` bash
 # Runs the ESP8266 network tests, requires a wifi access point
-mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --compile -DMBED_CFG_ESP8266_SSID='<SSID HERE>' -DMBED_CFG_ESP8266_PASS='<PASS HERE>'
+mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --compile -DMBED_CFG_ESP8266_SSID=<SSID HERE> -DMBED_CFG_ESP8266_PASS=<PASS HERE>
 mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --run --verbose
 ```
 
@@ -32,6 +32,6 @@ There are a couple other options that can be used during testing:
 For example, here is how to enabled the debug output from the ESP8266:
 ``` bash
 # Run the ESP8266 network tests with debug output, requires a wifi access point
-mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --compile -DMBED_CFG_ESP8266_SSID='<SSID HERE>' -DMBED_CFG_ESP8266_PASS='<PASS HERE>' -DMBED_CFG_ESP8266_DEBUG=true
+mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --compile -DMBED_CFG_ESP8266_SSID=<SSID HERE> -DMBED_CFG_ESP8266_PASS=<PASS HERE> -DMBED_CFG_ESP8266_DEBUG=true
 mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --run --verbose
 ```


### PR DESCRIPTION
In windows, apparently quotes are just copied into the definition of #defines passed on the command line. The quotes were originally to help users pass in non-alphabetic characters, but if it's going to cause problems on windows they should be omitted. Users on Linux or Mac can add the quotes themselves when needed.

Note: this is not an issue when using the config system or editting the file manually.

Need to check with @MarceloSalazar that this resolves the problem he was seeing.