### PR TITLE
Use host OS gethostbyname

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -85,29 +85,6 @@ int ESP8266Interface::connect()
     return NSAPI_ERROR_OK;
 }
 
-nsapi_error_t ESP8266Interface::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
-{
-    if (address->set_ip_address(name)) {
-        if (version != NSAPI_UNSPEC && address->get_ip_version() != version) {
-            return NSAPI_ERROR_DNS_FAILURE;
-        }
-
-        return NSAPI_ERROR_OK;
-    }
-    
-    char *ipbuff = new char[NSAPI_IP_SIZE];
-    int ret = 0;
-    
-    if(!_esp.dns_lookup(name, ipbuff)) {
-        ret = NSAPI_ERROR_DEVICE_ERROR;
-    } else {
-        address->set_ip_address(ipbuff);
-    }
-
-    delete[] ipbuff;
-    return ret;
-}
-
 int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
 {
     memset(ap_ssid, 0, sizeof(ap_ssid));

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -57,21 +57,7 @@ public:
      */
     virtual int connect(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE,
                                   uint8_t channel = 0);
-    
-    /** Translates a hostname to an IP address with specific version
-     *
-     *  The hostname may be either a domain name or an IP address. If the
-     *  hostname is an IP address, no network transactions will be performed.
-     *
-     *
-     *  @param host     Hostname to resolve
-     *  @param address  Destination for the host SocketAddress
-     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
-     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
-    
+
     /** Set the WiFi network credentials
      *
      *  @param ssid      Name of the network to connect to


### PR DESCRIPTION
The implementation of DNS lookup inside the ESP8266 firmware causes stack corruption when the name is 64 characters or longer.  This change uses the mbed OS implementation of gethostbyname instead to work around this bug.