### PR TITLE
Allow overriding the ESP8266 timeouts

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -19,10 +19,18 @@
 #include "mbed_debug.h"
 
 // Various timeouts for different ESP8266 operations
+#ifndef ESP8266_CONNECT_TIMEOUT
 #define ESP8266_CONNECT_TIMEOUT 15000
+#endif
+#ifndef ESP8266_SEND_TIMEOUT
 #define ESP8266_SEND_TIMEOUT    500
+#endif
+#ifndef ESP8266_RECV_TIMEOUT
 #define ESP8266_RECV_TIMEOUT    0
+#endif
+#ifndef ESP8266_MISC_TIMEOUT
 #define ESP8266_MISC_TIMEOUT    500
+#endif
 
 // Firmware version
 #define ESP8266_VERSION 2


### PR DESCRIPTION
By wrapping these in an `#ifndef` these can be overridden from user space (e.g. mbed_app.json). For a justification, see https://stackoverflow.com/questions/45328298/mbed-socket-connection-takes-a-long-time.

@geky @sarahmarshy 