### PR TITLE
Parameter fixes

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -143,7 +143,7 @@ int8_t ESP8266::getRSSI()
     char bssid[18];
 
    if (!(_parser.send("AT+CWJAP_CUR?")
-        && _parser.recv("+CWJAP_CUR::\"%*[^\"]\",\"%17[^\"]\"", bssid)
+        && _parser.recv("+CWJAP_CUR:\"%*[^\"]\",\"%17[^\"]\"", bssid)
         && _parser.recv("OK"))) {
         return 0;
     }

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -22,18 +22,28 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
     : _serial(tx, rx, ESP8266_DEFAULT_BAUD_RATE), 
       _parser(&_serial), 
       _packets(0), 
-      _packets_end(&_packets)
+      _packets_end(&_packets),
+      _connect_error(0),
+      _fail(false)
 {
     _serial.set_baud( ESP8266_DEFAULT_BAUD_RATE );
     _parser.debug_on(debug);
     _parser.set_delimiter("\r\n");
+    _parser.oob("+IPD", callback(this, &ESP8266::_packet_handler));
+    //Note: espressif at command document says that this should be +CWJAP_CUR:<error code>
+    //but seems that at least current version is not sending it
+    //https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf
+    //Also seems that ERROR is not sent, but FAIL instead
+    _parser.oob("+CWJAP:", callback(this, &ESP8266::_connect_error_handler));
+    //For future
+    _parser.oob("+CWJAP_CUR:", callback(this, &ESP8266::_connect_error_handler));
 }
 
 int ESP8266::get_firmware_version()
 {
     _parser.send("AT+GMR");
     int version;
-    if(_parser.recv("SDK version:%d", &version) && _parser.recv("OK")) {
+    if (_parser.recv("SDK version:%d", &version) && _parser.recv("OK")) {
         return version;
     } else { 
         // Older firmware versions do not prefix the version with "SDK version: "
@@ -45,18 +55,14 @@ int ESP8266::get_firmware_version()
 bool ESP8266::startup(int mode)
 {
     //only 3 valid modes
-    if(mode < 1 || mode > 3) {
+    if (mode < 1 || mode > 3) {
         return false;
     }
 
-    bool success = _parser.send("AT+CWMODE_CUR=%d", mode)
+    return _parser.send("AT+CWMODE_CUR=%d", mode)
         && _parser.recv("OK")
         && _parser.send("AT+CIPMUX=1")
         && _parser.recv("OK");
-
-    _parser.oob("+IPD", callback(this, &ESP8266::_packet_handler));
-    	
-    return success;
 }
 
 bool ESP8266::reset(void)
@@ -74,7 +80,7 @@ bool ESP8266::reset(void)
 bool ESP8266::dhcp(bool enabled, int mode)
 {
     //only 3 valid modes
-    if(mode < 0 || mode > 2) {
+    if (mode < 0 || mode > 2) {
         return false;
     }
 
@@ -82,31 +88,28 @@ bool ESP8266::dhcp(bool enabled, int mode)
         && _parser.recv("OK");
 }
 
-int ESP8266::connect(const char *ap, const char *passPhrase)
+nsapi_error_t ESP8266::connect(const char *ap, const char *passPhrase)
 {
-    int error_code = 0;
-    bool err = false;
-
     _parser.send("AT+CWJAP_CUR=\"%s\",\"%s\"", ap, passPhrase);
-    //if we don't get a +CWJAP and error code as a response, connection was success
-    //Note: espressif at command document says that this should be +CWJAP_CUR:<error code>
-    //but seems that at least current version is not sending it
-    //https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf
-    //Also seems that ERROR is not sent
-    err = _parser.recv("+CWJAP:%d", &error_code);
-    if(err) {
-        _parser.recv("FAIL");
-        if(error_code == 1)
-            return NSAPI_ERROR_CONNECTION_TIMEOUT;
-        else if(error_code == 2)
-            return NSAPI_ERROR_AUTH_FAILURE;
-        else if(error_code == 3)
-            return NSAPI_ERROR_NO_SSID;
-        else
-            return NSAPI_ERROR_NO_CONNECTION;
-    } else {
-        return NSAPI_ERROR_OK;
+    if (!_parser.recv("OK")) {
+        if (_fail) {
+            nsapi_error_t ret;
+            if (_connect_error == 1)
+                ret = NSAPI_ERROR_CONNECTION_TIMEOUT;
+            else if (_connect_error == 2)
+                ret = NSAPI_ERROR_AUTH_FAILURE;
+            else if (_connect_error == 3)
+                ret = NSAPI_ERROR_NO_SSID;
+            else
+                ret = NSAPI_ERROR_NO_CONNECTION;
+
+            _fail = false;
+            _connect_error = 0;
+            return ret;
+        }
     }
+
+    return NSAPI_ERROR_OK;
 }
 
 bool ESP8266::disconnect(void)
@@ -209,7 +212,7 @@ int ESP8266::scan(WiFiAccessPoint *res, unsigned limit)
 bool ESP8266::open(const char *type, int id, const char* addr, int port)
 {
     //IDs only 0-4
-    if(id > 4) {
+    if (id > 4) {
         return false;
     }
     return _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d", id, type, addr, port)
@@ -345,4 +348,15 @@ bool ESP8266::recv_ap(nsapi_wifi_ap_t *ap)
     ap->security = sec < 5 ? (nsapi_security_t)sec : NSAPI_SECURITY_UNKNOWN;
 
     return ret;
+}
+
+void ESP8266::_connect_error_handler()
+{
+    _fail = false;
+    _connect_error = 0;
+
+    if (_parser.recv("%d", &_connect_error) && _parser.recv("FAIL")) {
+        _fail = true;
+        _parser.abort();
+    }
 }

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -63,9 +63,9 @@ public:
     *
     * @param ap the name of the AP
     * @param passPhrase the password of AP
-    * @return true only if ESP8266 is connected successfully
+    * @return NSAPI_ERROR_OK only if ESP8266 is connected successfully
     */
-    int connect(const char *ap, const char *passPhrase);
+    nsapi_error_t connect(const char *ap, const char *passPhrase);
 
     /**
     * Disconnect ESP8266 from AP
@@ -217,12 +217,16 @@ private:
         // data follows
     } *_packets, **_packets_end;
     void _packet_handler();
+    void _connect_error_handler();
     bool recv_ap(nsapi_wifi_ap_t *ap);
 
     char _ip_buffer[16];
     char _gateway_buffer[16];
     char _netmask_buffer[16];
     char _mac_buffer[18];
+
+    int _connect_error;
+    bool _fail;
 };
 
 #endif

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -65,7 +65,7 @@ public:
     * @param passPhrase the password of AP
     * @return true only if ESP8266 is connected successfully
     */
-    bool connect(const char *ap, const char *passPhrase);
+    int connect(const char *ap, const char *passPhrase);
 
     /**
     * Disconnect ESP8266 from AP

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -41,6 +41,8 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
 {
     memset(_ids, 0, sizeof(_ids));
     memset(_cbs, 0, sizeof(_cbs));
+    memset(ap_ssid, 0, sizeof(ap_ssid));
+    memset(ap_pass, 0, sizeof(ap_pass));
 
     _esp.attach(this, &ESP8266Interface::event);
 }
@@ -80,6 +82,10 @@ int ESP8266Interface::connect()
 
     if (!_esp.dhcp(true, 1)) {
         return NSAPI_ERROR_DHCP_FAILURE;
+    }
+
+    if(ap_ssid[0] == 0) {
+        return NSAPI_ERROR_PARAMETER;
     }
 
     if (!_esp.connect(ap_ssid, ap_pass)) {

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -87,8 +87,8 @@ int ESP8266Interface::connect()
     if (!_esp.dhcp(true, 1)) {
         return NSAPI_ERROR_DHCP_FAILURE;
     }
-
-    if (int connect_error = _esp.connect(ap_ssid, ap_pass)) {
+    int connect_error = _esp.connect(ap_ssid, ap_pass);
+    if (connect_error) {
         return connect_error;
     }
 
@@ -103,28 +103,29 @@ int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_
 {
     ap_sec = security;
 
-    if(!ssid) {
+    if (!ssid) {
         return NSAPI_ERROR_PARAMETER;
     }
 
     int ssid_length = strlen(ssid);
 
-    if(ssid_length > 0 && ssid_length <= SSID_MAX_LENGTH) {
+    if (ssid_length > 0
+        && ssid_length <= ESP8266_SSID_MAX_LENGTH) {
         memset(ap_ssid, 0, sizeof(ap_ssid));
         strncpy(ap_ssid, ssid, sizeof(ap_ssid));
     } else {
         return NSAPI_ERROR_PARAMETER;
     }
 
-    if(ap_sec != NSAPI_SECURITY_NONE) {
+    if (ap_sec != NSAPI_SECURITY_NONE) {
 
-        if(!pass) {
+        if (!pass) {
             return NSAPI_ERROR_PARAMETER;
         }
 
         int pass_length = strlen(pass);
-        if(pass_length >= PASSPHRASE_MIN_LENGTH && pass_length <= PASSPHRASE_MAX_LENGTH )
-        {
+        if (pass_length >= ESP8266_PASSPHRASE_MIN_LENGTH
+            && pass_length <= ESP8266_PASSPHRASE_MAX_LENGTH ) {
             memset(ap_pass, 0, sizeof(ap_pass));
             strncpy(ap_pass, pass, sizeof(ap_pass));
         } else {

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -88,8 +88,8 @@ int ESP8266Interface::connect()
         return NSAPI_ERROR_DHCP_FAILURE;
     }
 
-    if (!_esp.connect(ap_ssid, ap_pass)) {
-        return NSAPI_ERROR_NO_CONNECTION;
+    if (int connect_error = _esp.connect(ap_ssid, ap_pass)) {
+        return connect_error;
     }
 
     if (!_esp.getIPAddress()) {

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -23,10 +23,6 @@
 
 #define ESP8266_SOCKET_COUNT 5
 
-#define SSID_MAX_LENGTH 32 /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
-#define PASSPHRASE_MAX_LENGTH 63 /* The longest allowed passphrase */
-#define PASSPHRASE_MIN_LENGTH 8 /* The shortest allowed passphrase */
-
 /** ESP8266Interface class
  *  Implementation of the NetworkStack for the ESP8266
  */
@@ -260,13 +256,17 @@ protected:
     }
 
 private:
+    static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
+    static const int ESP8266_PASSPHRASE_MAX_LENGTH = 63; /* The longest allowed passphrase */
+    static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
+
     ESP8266 _esp;
     bool _ids[ESP8266_SOCKET_COUNT];
 
-    char ap_ssid[SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
+    char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     nsapi_security_t ap_sec;
     uint8_t ap_ch;
-    char ap_pass[PASSPHRASE_MAX_LENGTH + 1]; /* The longest allowed passphrase */
+    char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
 
     void event();
 

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -23,6 +23,10 @@
 
 #define ESP8266_SOCKET_COUNT 5
 
+#define SSID_MAX_LENGTH 32 /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
+#define PASSPHRASE_MAX_LENGTH 63 /* The longest allowed passphrase */
+#define PASSPHRASE_MIN_LENGTH 8 /* The shortest allowed passphrase */
+
 /** ESP8266Interface class
  *  Implementation of the NetworkStack for the ESP8266
  */
@@ -259,10 +263,10 @@ private:
     ESP8266 _esp;
     bool _ids[ESP8266_SOCKET_COUNT];
 
-    char ap_ssid[33]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
+    char ap_ssid[SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     nsapi_security_t ap_sec;
     uint8_t ap_ch;
-    char ap_pass[64]; /* The longest allowed passphrase */
+    char ap_pass[PASSPHRASE_MAX_LENGTH + 1]; /* The longest allowed passphrase */
 
     void event();
 


### PR DESCRIPTION
This PR fixes 2 issues

1.
ap_ssid and ap_pass were uninitialized in the constructor, this caused the interface to possibly try connecting to a ssid with random garbage as a name, same with the password.

2.
Extra colon in expected AT-command response caused that bssid of current network was never got and could not be used to get the RSSI from CWLAP-command, instead an uninitialized garbage value was used.