### PR TITLE
Remove OOB for +CWJAP_CUR:

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -35,8 +35,6 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
     //https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf
     //Also seems that ERROR is not sent, but FAIL instead
     _parser.oob("+CWJAP:", callback(this, &ESP8266::_connect_error_handler));
-    //For future
-    _parser.oob("+CWJAP_CUR:", callback(this, &ESP8266::_connect_error_handler));
 }
 
 int ESP8266::get_firmware_version()


### PR DESCRIPTION
When connecting, +CWJAP_CUR is not used for reporting error codes, according to documentation it should be
[Documentation](https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf)

However it clashes with normal +CWJAP_CUR -response with normal expected response values, therefore the OOB for +CWJAP_CUR is removed, it was there for possible future usage.
