### PR TITLE
ESP8266 retrieval of AP list made possible without need to run connect()

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -185,10 +185,10 @@ bool ESP8266::isConnected(void)
     const char *ip_buff = getIPAddress();
 
     if(!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
-        return 0;
+        return false;
     }
 
-    return ip_buff;
+    return true;
 }
 
 int ESP8266::scan(WiFiAccessPoint *res, unsigned limit)

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "ESP8266.h"
+#include <string.h>
 
 #define   ESP8266_DEFAULT_BAUD_RATE   115200
 
@@ -82,7 +83,7 @@ bool ESP8266::dhcp(bool enabled, int mode)
         return false;
     }
 
-    return _parser.send("AT+CWDHCP_CUR=%d,%d", enabled?1:0, mode)
+    return _parser.send("AT+CWDHCP_CUR=%d,%d", mode, enabled?1:0)
         && _parser.recv("OK");
 }
 
@@ -120,6 +121,10 @@ const char *ESP8266::getIPAddress(void)
     if (!(_parser.send("AT+CIFSR")
         && _parser.recv("+CIFSR:STAIP,\"%15[^\"]\"", _ip_buffer)
         && _parser.recv("OK"))) {
+        return 0;
+    }
+
+    if(std::strncmp(_ip_buffer, "0.0.0.0", sizeof(*_ip_buffer)) == 0) {
         return 0;
     }
 

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "ESP8266.h"
-#include <string.h>
+#include <cstring>
 
 #define   ESP8266_DEFAULT_BAUD_RATE   115200
 
@@ -124,10 +124,6 @@ const char *ESP8266::getIPAddress(void)
         return 0;
     }
 
-    if(std::strncmp(_ip_buffer, "0.0.0.0", sizeof(*_ip_buffer)) == 0) {
-        return 0;
-    }
-
     return _ip_buffer;
 }
 
@@ -186,7 +182,13 @@ int8_t ESP8266::getRSSI()
 
 bool ESP8266::isConnected(void)
 {
-    return getIPAddress() != 0;
+    const char *ip_buff = getIPAddress();
+
+    if(!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
+        return 0;
+    }
+
+    return ip_buff;
 }
 
 int ESP8266::scan(WiFiAccessPoint *res, unsigned limit)

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -65,18 +65,21 @@ int ESP8266Interface::connect(const char *ssid, const char *pass, nsapi_security
 
 int ESP8266Interface::connect()
 {
-    nsapi_error_t fw_status = get_firmware_ok();
-    size_t ssid_length = strlen(ap_ssid);
-    size_t pass_length = strlen(ap_pass);
+    const size_t ssid_length = strlen(ap_ssid);
+    const size_t pass_length = strlen(ap_pass);
 
     _esp.setTimeout(ESP8266_MISC_TIMEOUT);
 
     if(_esp.isConnected()) {
-        return NSAPI_ERROR_ALREADY;
+        return NSAPI_ERROR_IS_CONNECTED;
     }
 
     _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
     if (!_esp.reset()) {
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+
+    if (get_firmware_ok() != NSAPI_ERROR_OK) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }
 
@@ -88,10 +91,6 @@ int ESP8266Interface::connect()
         if (pass_length < ESP8266_PASSPHRASE_MIN_LENGTH) {
             return NSAPI_ERROR_PARAMETER;
         }
-    }
-
-    if (fw_status != NSAPI_ERROR_OK) {
-        return fw_status;
     }
 
     _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -256,6 +256,7 @@ protected:
     }
 
 private:
+    nsapi_error_t get_firmware_ok();
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
     static const int ESP8266_PASSPHRASE_MAX_LENGTH = 63; /* The longest allowed passphrase */
     static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */


### PR DESCRIPTION
It was not possible to scan before Wifi connect was run. The HW module is
also reset only when the driver is initialized - not in each connect as
it was previously. Reconnecting also requires first running disconnect
from now on. Fixed a bug from dhcp() - mode and enable bits were mixed
with each other when given to ATParser.