### PR TITLE
Disable softap and make the driver to track its own state

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -180,17 +180,6 @@ int8_t ESP8266::getRSSI()
     return rssi;
 }
 
-bool ESP8266::isConnected(void)
-{
-    const char *ip_buff = getIPAddress();
-
-    if(!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
-        return false;
-    }
-
-    return true;
-}
-
 int ESP8266::scan(WiFiAccessPoint *res, unsigned limit)
 {
     unsigned cnt = 0;
@@ -233,7 +222,7 @@ bool ESP8266::send(int id, const void *data, uint32_t amount)
 {
     //May take a second try if device is busy
     for (unsigned i = 0; i < 2; i++) {
-        if (_parser.send("AT+CIPSEND=%d,%d", id, amount)
+        if (_parser.send("AT+CIPSEND=%d,%lu", id, amount)
             && _parser.recv(">")
             && _parser.write((char*)data, (int)amount) >= 0) {
             return true;
@@ -249,7 +238,7 @@ void ESP8266::_packet_handler()
     uint32_t amount;
 
     // parse out the packet
-    if (!_parser.recv(",%d,%d:", &id, &amount)) {
+    if (!_parser.recv(",%d,%lu:", &id, &amount)) {
         return;
     }
 
@@ -384,5 +373,3 @@ bool ESP8266::set_default_wifi_mode(const int8_t mode)
     return _parser.send("AT+CWMODE_DEF=%hhd", mode)
         && _parser.recv("OK");
 }
-
-

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -108,13 +108,6 @@ public:
      */
     int8_t getRSSI();
 
-    /**
-    * Check if ESP8266 is conenected
-    *
-    * @return true only if the chip has an IP address
-    */
-    bool isConnected(void);
-
     /** Scan for available networks
      *
      * @param  ap    Pointer to allocated array to store discovered AP

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -206,6 +206,22 @@ public:
         attach(Callback<void()>(obj, method));
     }
 
+    /**
+     * Read default Wifi mode from flash
+     *
+     * return Station, SoftAP or SoftAP+Station - 0 on failure
+     */
+    int8_t get_default_wifi_mode();
+
+    /**
+     * Write default Wifi mode to flash
+     */
+    bool set_default_wifi_mode(const int8_t mode);
+
+    static const int8_t WIFIMODE_STATION = 1;
+    static const int8_t WIFIMODE_SOFTAP = 2;
+    static const int8_t WIFIMODE_STATION_SOFTAP = 3;
+
 private:
     UARTSerial _serial;
     ATCmdParser _parser;

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -49,6 +49,7 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
     ap_sec = NSAPI_SECURITY_UNKNOWN;
 
     _esp.attach(this, &ESP8266Interface::event);
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
 }
 
 int ESP8266Interface::connect(const char *ssid, const char *pass, nsapi_security_t security,
@@ -95,12 +96,13 @@ int ESP8266Interface::connect()
     }
     _started = true;
 
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (!_esp.dhcp(true, 1)) {
         return NSAPI_ERROR_DHCP_FAILURE;
     }
-    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
+    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT); // Exception
     int connect_error = _esp.connect(ap_ssid, ap_pass);
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT); // Assumed everywhere else
+
     if (connect_error) {
         return connect_error;
     }
@@ -162,7 +164,6 @@ int ESP8266Interface::disconnect()
     _started = false;
     _initialized = false;
 
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (!_esp.disconnect()) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }
@@ -176,7 +177,6 @@ const char *ESP8266Interface::get_ip_address()
         return NULL;
     }
 
-    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
     const char *ip_buff = _esp.getIPAddress();
     if(!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
         return NULL;
@@ -187,7 +187,6 @@ const char *ESP8266Interface::get_ip_address()
 
 const char *ESP8266Interface::get_mac_address()
 {
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     return _esp.getMACAddress();
 }
 
@@ -196,7 +195,6 @@ const char *ESP8266Interface::get_gateway()
     if(!_started) {
         return NULL;
     }
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     return _esp.getGateway();
 }
 
@@ -205,7 +203,6 @@ const char *ESP8266Interface::get_netmask()
     if(!_started) {
         return NULL;
     }
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     return _esp.getNetmask();
 }
 
@@ -214,7 +211,6 @@ int8_t ESP8266Interface::get_rssi()
     if(!_started) {
         return 0;
     }
-    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
     return _esp.getRSSI();
 }
 
@@ -232,13 +228,15 @@ int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count)
         return status;
     }
 
-    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-    return _esp.scan(res, count);
+    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT); // Exception
+    int cnt = _esp.scan(res, count);
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT); // Assumed everywhere else
+
+    return cnt;
 }
 
 bool ESP8266Interface::_get_firmware_ok()
 {
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (_esp.get_firmware_version() != ESP8266_VERSION) {
         debug("ESP8266: ERROR: Firmware incompatible with this driver.\
                \r\nUpdate to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n",ESP8266_VERSION);
@@ -252,7 +250,6 @@ bool ESP8266Interface::_disable_default_softap()
 {
     static int disabled = false;
 
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (disabled || _esp.get_default_wifi_mode() == ESP8266::WIFIMODE_STATION) {
         disabled = true;
         return true;
@@ -267,9 +264,14 @@ bool ESP8266Interface::_disable_default_softap()
 
 nsapi_error_t ESP8266Interface::_init(void)
 {
+    bool reset_ok;
+
     if (!_initialized) {
-        _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-        if (!_esp.reset()) {
+        _esp.setTimeout(ESP8266_CONNECT_TIMEOUT); // Exception
+        reset_ok = _esp.reset();
+        _esp.setTimeout(ESP8266_MISC_TIMEOUT); // Assumed everywhere else
+
+        if (!reset_ok) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (_get_firmware_ok() != NSAPI_ERROR_OK) {
@@ -285,11 +287,15 @@ nsapi_error_t ESP8266Interface::_init(void)
 
 nsapi_error_t ESP8266Interface::_startup(const int8_t wifi_mode)
 {
+    bool startup_ok;
+
     if (!_started) {
-        _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-        if (!_esp.startup(wifi_mode)) {
+        startup_ok = _esp.startup(wifi_mode);
+
+        if (!startup_ok) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
+
     }
     return NSAPI_ERROR_OK;
 }
@@ -334,7 +340,6 @@ int ESP8266Interface::socket_close(void *handle)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     int err = 0;
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
  
     if (socket->connected && !_esp.close(socket->id)) {
         err = NSAPI_ERROR_DEVICE_ERROR;
@@ -359,7 +364,6 @@ int ESP8266Interface::socket_listen(void *handle, int backlog)
 int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
 
     const char *proto = (socket->proto == NSAPI_UDP) ? "UDP" : "TCP";
     if (!_esp.open(proto, socket->id, addr.get_ip_address(), addr.get_port())) {
@@ -405,7 +409,6 @@ int ESP8266Interface::socket_sendto(void *handle, const SocketAddress &addr, con
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
 
     if (socket->connected && socket->addr != addr) {
-        _esp.setTimeout(ESP8266_MISC_TIMEOUT);
         if (!_esp.close(socket->id)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -38,7 +38,9 @@
 
 // ESP8266Interface implementation
 ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
-    : _esp(tx, rx, debug)
+    : _esp(tx, rx, debug),
+      _initialized(false),
+      _started(false)
 {
     memset(_ids, 0, sizeof(_ids));
     memset(_cbs, 0, sizeof(_cbs));
@@ -66,53 +68,44 @@ int ESP8266Interface::connect(const char *ssid, const char *pass, nsapi_security
 
 int ESP8266Interface::connect()
 {
-    const size_t ssid_length = strlen(ap_ssid);
-    const size_t pass_length = strlen(ap_pass);
+    nsapi_error_t status;
 
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
-    if(_esp.isConnected()) {
-        return NSAPI_ERROR_IS_CONNECTED;
-    }
-
-    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-    if (!_esp.reset()) {
-        return NSAPI_ERROR_DEVICE_ERROR;
-    }
-
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
-    if (disable_default_softap() == false) {
-        return NSAPI_ERROR_DEVICE_ERROR;
-    }
-
-    if (get_firmware_ok() != NSAPI_ERROR_OK) {
-        return NSAPI_ERROR_DEVICE_ERROR;
-    }
-
-    if (ssid_length == 0) {
+    if (strlen(ap_ssid) == 0) {
         return NSAPI_ERROR_NO_SSID;
     }
 
     if (ap_sec != NSAPI_SECURITY_NONE) {
-        if (pass_length < ESP8266_PASSPHRASE_MIN_LENGTH) {
+        if (strlen(ap_pass) < ESP8266_PASSPHRASE_MIN_LENGTH) {
             return NSAPI_ERROR_PARAMETER;
         }
     }
 
-    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-
-    if (!_esp.startup(ESP8266::WIFIMODE_STATION)) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+    status = _init();
+    if(status != NSAPI_ERROR_OK) {
+        return status;
     }
 
+    if(get_ip_address()) {
+        return NSAPI_ERROR_IS_CONNECTED;
+    }
+
+    status = _startup(ESP8266::WIFIMODE_STATION);
+    if(status != NSAPI_ERROR_OK) {
+        return status;
+    }
+    _started = true;
+
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (!_esp.dhcp(true, 1)) {
         return NSAPI_ERROR_DHCP_FAILURE;
     }
+    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
     int connect_error = _esp.connect(ap_ssid, ap_pass);
     if (connect_error) {
         return connect_error;
     }
 
-    if (!_esp.getIPAddress()) {
+    if (!get_ip_address()) {
         return NSAPI_ERROR_DHCP_FAILURE;
     }
 
@@ -166,8 +159,10 @@ int ESP8266Interface::set_channel(uint8_t channel)
 
 int ESP8266Interface::disconnect()
 {
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
+    _started = false;
+    _initialized = false;
 
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (!_esp.disconnect()) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }
@@ -177,56 +172,73 @@ int ESP8266Interface::disconnect()
 
 const char *ESP8266Interface::get_ip_address()
 {
-    return _esp.getIPAddress();
+    if(!_started) {
+        return NULL;
+    }
+
+    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
+    const char *ip_buff = _esp.getIPAddress();
+    if(!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
+        return NULL;
+    }
+
+    return ip_buff;
 }
 
 const char *ESP8266Interface::get_mac_address()
 {
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     return _esp.getMACAddress();
 }
 
 const char *ESP8266Interface::get_gateway()
 {
+    if(!_started) {
+        return NULL;
+    }
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     return _esp.getGateway();
 }
 
 const char *ESP8266Interface::get_netmask()
 {
+    if(!_started) {
+        return NULL;
+    }
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     return _esp.getNetmask();
 }
 
 int8_t ESP8266Interface::get_rssi()
 {
+    if(!_started) {
+        return 0;
+    }
+    _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
     return _esp.getRSSI();
 }
 
 int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count)
 {
-    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
-    if(!_esp.isConnected()) {
-        _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
-        if (!_esp.reset()) {
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
+    nsapi_error_t status;
 
-        _esp.setTimeout(ESP8266_MISC_TIMEOUT);
-        if (get_firmware_ok() != NSAPI_ERROR_OK) {
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
-        if (disable_default_softap() == false) {
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
-        if(_esp.startup(ESP8266::WIFIMODE_STATION) == false) {
-            return NSAPI_ERROR_DEVICE_ERROR;
-        }
+    status = _init();
+    if(status != NSAPI_ERROR_OK) {
+        return status;
+    }
+
+    status = _startup(ESP8266::WIFIMODE_STATION);
+    if(status != NSAPI_ERROR_OK) {
+        return status;
     }
 
     _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
     return _esp.scan(res, count);
 }
 
-nsapi_error_t ESP8266Interface::get_firmware_ok()
+bool ESP8266Interface::_get_firmware_ok()
 {
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
     if (_esp.get_firmware_version() != ESP8266_VERSION) {
         debug("ESP8266: ERROR: Firmware incompatible with this driver.\
                \r\nUpdate to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n",ESP8266_VERSION);
@@ -236,13 +248,50 @@ nsapi_error_t ESP8266Interface::get_firmware_ok()
     return NSAPI_ERROR_OK;
 }
 
-bool ESP8266Interface::disable_default_softap()
+bool ESP8266Interface::_disable_default_softap()
 {
-    if (_esp.get_default_wifi_mode() == ESP8266::WIFIMODE_STATION) {
+    static int disabled = false;
+
+    _esp.setTimeout(ESP8266_MISC_TIMEOUT);
+    if (disabled || _esp.get_default_wifi_mode() == ESP8266::WIFIMODE_STATION) {
+        disabled = true;
+        return true;
+    }
+    if (_esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION)) {
+        disabled = true;
         return true;
     }
 
-    return _esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION);
+    return false;
+}
+
+nsapi_error_t ESP8266Interface::_init(void)
+{
+    if (!_initialized) {
+        _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
+        if (!_esp.reset()) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        if (_get_firmware_ok() != NSAPI_ERROR_OK) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        if (_disable_default_softap() == false) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        _initialized = true;
+    }
+    return NSAPI_ERROR_OK;
+}
+
+nsapi_error_t ESP8266Interface::_startup(const int8_t wifi_mode)
+{
+    if (!_started) {
+        _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
+        if (!_esp.startup(wifi_mode)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+    }
+    return NSAPI_ERROR_OK;
 }
 
 struct esp8266_socket {

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -262,15 +262,19 @@ private:
 
     ESP8266 _esp;
     bool _ids[ESP8266_SOCKET_COUNT];
+    int _initialized;
+    int _started;
 
     char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     nsapi_security_t ap_sec;
     uint8_t ap_ch;
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
 
-    bool disable_default_softap();
+    bool _disable_default_softap();
     void event();
-    nsapi_error_t get_firmware_ok();
+    bool _get_firmware_ok();
+    nsapi_error_t _init(void);
+    nsapi_error_t _startup(const int8_t wifi_mode);
 
     struct {
         void (*callback)(void *);

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -256,7 +256,6 @@ protected:
     }
 
 private:
-    nsapi_error_t get_firmware_ok();
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
     static const int ESP8266_PASSPHRASE_MAX_LENGTH = 63; /* The longest allowed passphrase */
     static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
@@ -269,7 +268,9 @@ private:
     uint8_t ap_ch;
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
 
+    bool disable_default_softap();
     void event();
+    nsapi_error_t get_firmware_ok();
 
     struct {
         void (*callback)(void *);


### PR DESCRIPTION
Configures the Wifi chip as Station and makes it permanent by writing it also to flash.

The driver tracks its state now on rudimentary level to avoid the situations that HW has not been powered of on reset and causes the driver to be in inconsistent state.

As a minor detail took care of couple of format string warnings.
