### PR TITLE
Making it possible to bind UDP client to a local port

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -248,15 +248,22 @@ int ESP8266::scan(WiFiAccessPoint *res, unsigned limit)
     return cnt;
 }
 
-bool ESP8266::open(const char *type, int id, const char* addr, int port)
+bool ESP8266::open(const char *type, int id, const char* addr, int port, int local_port)
 {
+    bool done;
+
     //IDs only 0-4
     if (id > 4) {
         return false;
     }
     _smutex.lock();
-    bool done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d", id, type, addr, port)
-                && _parser.recv("OK");
+    if(local_port) {
+        done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d,%d", id, type, addr, port, local_port)
+               && _parser.recv("OK");
+    } else {
+        done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d", id, type, addr, port)
+               && _parser.recv("OK");
+    }
     _smutex.unlock();
 
     return done;

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -135,7 +135,7 @@ public:
     * @param addr the IP address of the destination
     * @return true only if socket opened successfully
     */
-    bool open(const char *type, int id, const char* addr, int port);
+    bool open(const char *type, int id, const char* addr, int port, int local_port=0);
 
     /**
     * Sends data to an open socket

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -18,6 +18,7 @@
 #include "ESP8266.h"
 #include "ESP8266Interface.h"
 #include "mbed_debug.h"
+#include "nsapi_types.h"
 
 // Various timeouts for different ESP8266 operations
 #ifndef ESP8266_CONNECT_TIMEOUT
@@ -46,6 +47,7 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
+    memset(_local_ports, 0, sizeof(_local_ports));
     ap_sec = NSAPI_SECURITY_UNKNOWN;
 
     _esp.attach(this, &ESP8266Interface::event);
@@ -342,12 +344,23 @@ int ESP8266Interface::socket_close(void *handle)
 
     socket->connected = false;
     _ids[socket->id] = false;
+    _local_ports[socket->id] = 0;
     delete socket;
     return err;
 }
 
 int ESP8266Interface::socket_bind(void *handle, const SocketAddress &address)
 {
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (socket->proto == NSAPI_UDP) {
+        if(address.get_addr().version != NSAPI_UNSPEC) {
+            return NSAPI_ERROR_UNSUPPORTED;
+        }
+        _local_ports[socket->id] = address.get_port();
+        return 0;
+    }
+
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
@@ -362,10 +375,10 @@ int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
     _esp.setTimeout(ESP8266_MISC_TIMEOUT);
 
     const char *proto = (socket->proto == NSAPI_UDP) ? "UDP" : "TCP";
-    if (!_esp.open(proto, socket->id, addr.get_ip_address(), addr.get_port())) {
+    if (!_esp.open(proto, socket->id, addr.get_ip_address(), addr.get_port(), _local_ports[socket->id])) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }
-    
+
     socket->connected = true;
     return 0;
 }

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -357,6 +357,14 @@ int ESP8266Interface::socket_bind(void *handle, const SocketAddress &address)
         if(address.get_addr().version != NSAPI_UNSPEC) {
             return NSAPI_ERROR_UNSUPPORTED;
         }
+
+        for(int id = 0; id < ESP8266_SOCKET_COUNT; id++) {
+            if(_local_ports[id] == address.get_port() && id != socket->id) { // Port already reserved by another socket
+                return NSAPI_ERROR_PARAMETER;
+            } else if (id == socket->id && socket->connected) {
+                return NSAPI_ERROR_PARAMETER;
+            }
+        }
         _local_ports[socket->id] = address.get_port();
         return 0;
     }

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -269,6 +269,7 @@ private:
     nsapi_security_t ap_sec;
     uint8_t ap_ch;
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
+    uint16_t _local_ports[ESP8266_SOCKET_COUNT];
 
     bool _disable_default_softap();
     void event();

--- a/README.md
+++ b/README.md
@@ -4,34 +4,6 @@ The mbed OS driver for the ESP8266 WiFi module
 ## Firmware version
 ESP8266 modules come in different shapes and forms, but most important difference is which firmware version it is programmed with. To make sure that your module has mbed-os compatible firmware follow update guide: https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update
 
-## Testing
-The ESP8266 library contains the core network tests taken from mbed OS. To run the tests you will need mbed CLI and mbed OS.
-
-First, setup the the esp8266-driver and mbed-os repositories for testing:
-``` bash
-# Sets up the ESP8266 for testing
-mbed import esp8266-driver
-cd esp8266-driver
-mbed add mbed-os
-```
-
-Now you should be able to run the network tests with `mbed test`:
-``` bash
-# Runs the ESP8266 network tests, requires a wifi access point
-mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --compile -DMBED_CFG_ESP8266_SSID=<SSID HERE> -DMBED_CFG_ESP8266_PASS=<PASS HERE>
-mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --run --verbose
-```
-
-There are a couple other options that can be used during testing:
-- MBED_CFG_ESP8266_SSID - SSID of the wifi access point to connect to
-- MBED_CFG_ESP8266_PASS - Passphrase of the wifi access point to connect to
-- MBED_CFG_ESP8266_TX - TX pin for the ESP8266 serial connection (defaults to D1)
-- MBED_CFG_ESP8266_RX - TX pin for the ESP8266 serial connection (defaults to D0)
-- MBED_CFG_ESP8266_DEBUG - Enabled debug output from the ESP8266
-
-For example, here is how to enabled the debug output from the ESP8266:
-``` bash
-# Run the ESP8266 network tests with debug output, requires a wifi access point
-mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --compile -DMBED_CFG_ESP8266_SSID=<SSID HERE> -DMBED_CFG_ESP8266_PASS=<PASS HERE> -DMBED_CFG_ESP8266_DEBUG=true
-mbed test -t <COMPILER HERE> -m <BOARD HERE> -n tests-net* --run --verbose
-```
+## Restrictions
+- The ESP8266 WiFi module does not allow TCP client to bind on a specific port
+- Setting up an UDP server is not possible


### PR DESCRIPTION
ESP8266 does not support binding a TCP client to a certain local port but its possible to achieve this in case of UDP.

README.md updated to include the Restrictions-section. Instructions how to compile and run deprecated test cases have been removed.