### PR TITLE
Makes sending data in bursts possible

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -286,6 +286,7 @@ bool ESP8266::send(int id, const void *data, uint32_t amount)
         if (_parser.send("AT+CIPSEND=%d,%lu", id, amount)
             && _parser.recv(">")
             && _parser.write((char*)data, (int)amount) >= 0) {
+            _parser.process_oob(); // multiple sends in a row require this
             _smutex.unlock();
             return true;
         }


### PR DESCRIPTION
Beforehand sending data in bursts was not possible due to corruption.
For not known reason increasing OOB data handling frequency seems to make
things better.