### PR TITLE
Fix channel numbers detected during wifi scan

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -490,9 +490,15 @@ void ESP8266::attach(Callback<void()> func)
 bool ESP8266::recv_ap(nsapi_wifi_ap_t *ap)
 {
     int sec;
-    bool ret = _parser.recv("+CWLAP:(%d,\"%32[^\"]\",%hhd,\"%hhx:%hhx:%hhx:%hhx:%hhx:%hhx\",%hhu", &sec, ap->ssid,
-                            &ap->rssi, &ap->bssid[0], &ap->bssid[1], &ap->bssid[2], &ap->bssid[3], &ap->bssid[4],
-                            &ap->bssid[5], &ap->channel);
+    int dummy;
+    bool ret = _parser.recv("+CWLAP:(%d,\"%32[^\"]\",%hhd,\"%hhx:%hhx:%hhx:%hhx:%hhx:%hhx\",%hhu,%d,%d)\n",
+            &sec,
+            ap->ssid,
+            &ap->rssi,
+            &ap->bssid[0], &ap->bssid[1], &ap->bssid[2], &ap->bssid[3], &ap->bssid[4], &ap->bssid[5],
+            &ap->channel,
+            &dummy,
+            &dummy);
 
     ap->security = sec < 5 ? (nsapi_security_t)sec : NSAPI_SECURITY_UNKNOWN;
 

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -244,10 +244,10 @@ bool ESP8266Interface::_get_firmware_ok()
     if (_esp.get_firmware_version() != ESP8266_VERSION) {
         debug("ESP8266: ERROR: Firmware incompatible with this driver.\
                \r\nUpdate to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n",ESP8266_VERSION);
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return false;
     }
 
-    return NSAPI_ERROR_OK;
+    return true;
 }
 
 bool ESP8266Interface::_disable_default_softap()
@@ -274,7 +274,7 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_esp.reset()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
-        if (_get_firmware_ok() != NSAPI_ERROR_OK) {
+        if (!_get_firmware_ok()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (_disable_default_softap() == false) {


### PR DESCRIPTION
The previous implementation was happy just for seeing a single digit and accepted is as the channel number. From now on the AT parser is required to read a whole line at a time.