### PR TITLE
Add support for attaching a status callback for esp8266 driver

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -29,7 +29,8 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
       _packets_end(&_packets),
       _connect_error(0),
       _fail(false),
-      _socket_open()
+      _socket_open(),
+      _connection_status(NSAPI_STATUS_DISCONNECTED)
 {
     _serial.set_baud( ESP8266_DEFAULT_BAUD_RATE );
     _parser.debug_on(debug);
@@ -45,6 +46,7 @@ ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
     _parser.oob("2,CLOSED", callback(this, &ESP8266::_oob_socket2_closed_handler));
     _parser.oob("3,CLOSED", callback(this, &ESP8266::_oob_socket3_closed_handler));
     _parser.oob("4,CLOSED", callback(this, &ESP8266::_oob_socket4_closed_handler));
+    _parser.oob("WIFI ", callback(this, &ESP8266::_connection_status_handler));
 }
 
 int ESP8266::get_firmware_version()
@@ -122,6 +124,9 @@ nsapi_error_t ESP8266::connect(const char *ap, const char *passPhrase)
 {
     _smutex.lock();
     setTimeout(ESP8266_CONNECT_TIMEOUT);
+    _connection_status = NSAPI_STATUS_CONNECTING;
+    if(_connection_status_cb)
+        _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);
 
     _parser.send("AT+CWJAP_CUR=\"%s\",\"%s\"", ap, passPhrase);
     if (!_parser.recv("OK\n")) {
@@ -503,9 +508,14 @@ bool ESP8266::writeable()
     return _serial.FileHandle::writable();
 }
 
-void ESP8266::attach(Callback<void()> func)
+void ESP8266::sigio(Callback<void()> func)
 {
     _serial.sigio(func);
+}
+
+void ESP8266::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+{
+    _connection_status_cb = status_cb;
 }
 
 bool ESP8266::recv_ap(nsapi_wifi_ap_t *ap)
@@ -562,6 +572,23 @@ void ESP8266::_oob_socket4_closed_handler()
     _socket_open[4] = 0;
 }
 
+void ESP8266::_connection_status_handler()
+{
+    char status[13];
+    if (_parser.recv("%12[^\"]\n", status)) {
+        if (strcmp(status, "CONNECTED\n") == 0)
+            _connection_status = NSAPI_STATUS_LOCAL_UP;
+        else if (strcmp(status, "GOT IP\n") == 0)
+            _connection_status = NSAPI_STATUS_GLOBAL_UP;
+        else //DISCONNECTED or unknown
+            _connection_status = NSAPI_STATUS_DISCONNECTED;
+
+        if(_connection_status_cb)
+            _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);
+
+    }
+}
+
 int8_t ESP8266::get_default_wifi_mode()
 {
     int8_t mode;
@@ -586,4 +613,9 @@ bool ESP8266::set_default_wifi_mode(const int8_t mode)
     _smutex.unlock();
 
     return done;
+}
+
+nsapi_connection_status_t ESP8266::get_connection_status() const
+{
+    return _connection_status;
 }

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -576,16 +576,15 @@ void ESP8266::_connection_status_handler()
 {
     char status[13];
     if (_parser.recv("%12[^\"]\n", status)) {
-        if (strcmp(status, "CONNECTED\n") == 0)
-            _connection_status = NSAPI_STATUS_LOCAL_UP;
-        else if (strcmp(status, "GOT IP\n") == 0)
+        if (strcmp(status, "GOT IP\n") == 0)
             _connection_status = NSAPI_STATUS_GLOBAL_UP;
-        else //DISCONNECTED or unknown
+        else if (strcmp(status, "DISCONNECT\n") == 0)
             _connection_status = NSAPI_STATUS_DISCONNECTED;
+        else
+            return;
 
         if(_connection_status_cb)
             _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);
-
     }
 }
 

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -223,22 +223,29 @@ public:
     bool writeable();
 
     /**
-    * Attach a function to call whenever network state has changed
+    * Attach a function to call whenever sigio happens in the serial
     *
     * @param func A pointer to a void function, or 0 to set as none
     */
-    void attach(Callback<void()> func);
+    void sigio(Callback<void()> func);
 
     /**
-    * Attach a function to call whenever network state has changed
+    * Attach a function to call whenever sigio happens in the serial
     *
     * @param obj pointer to the object to call the member function on
     * @param method pointer to the member function to call
     */
     template <typename T, typename M>
-    void attach(T *obj, M method) {
-        attach(Callback<void()>(obj, method));
+    void sigio(T *obj, M method) {
+        sigio(Callback<void()>(obj, method));
     }
+
+    /**
+    * Attach a function to call whenever network state has changed
+    *
+    * @param func A pointer to a void function, or 0 to set as none
+    */
+    void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
     /**
      * Read default Wifi mode from flash
@@ -251,6 +258,12 @@ public:
      * Write default Wifi mode to flash
      */
     bool set_default_wifi_mode(const int8_t mode);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    nsapi_connection_status_t get_connection_status() const;
 
     static const int8_t WIFIMODE_STATION = 1;
     static const int8_t WIFIMODE_SOFTAP = 2;
@@ -276,7 +289,7 @@ private:
     void _oob_socket2_closed_handler();
     void _oob_socket3_closed_handler();
     void _oob_socket4_closed_handler();
-
+    void _connection_status_handler();
 
     char _ip_buffer[16];
     char _gateway_buffer[16];
@@ -286,6 +299,8 @@ private:
     int _connect_error;
     bool _fail;
     int _socket_open[SOCKET_COUNT];
+    nsapi_connection_status_t _connection_status;
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 
 #endif

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -37,7 +37,7 @@ ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
     memset(_local_ports, 0, sizeof(_local_ports));
     ap_sec = NSAPI_SECURITY_UNKNOWN;
 
-    _esp.attach(this, &ESP8266Interface::event);
+    _esp.sigio(this, &ESP8266Interface::event);
     _esp.setTimeout();
 }
 
@@ -490,10 +490,21 @@ nsapi_error_t ESP8266Interface::getsockopt(nsapi_socket_t handle, int level, int
 }
 
 
-void ESP8266Interface::event() {
+void ESP8266Interface::event()
+{
     for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
         if (_cbs[i].callback) {
             _cbs[i].callback(_cbs[i].data);
         }
     }
+}
+
+void ESP8266Interface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+{
+    _esp.attach(status_cb);
+}
+
+nsapi_connection_status_t ESP8266Interface::get_connection_status() const
+{
+    return _esp.get_connection_status();
 }

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -147,7 +147,7 @@ public:
      */
     using NetworkInterface::add_dns_server;
 
-    /*  Set socket options
+    /** Set socket options
      *
      *  The setsockopt allow an application to pass stack-specific hints
      *  to the underlying stack. For unsupported options,
@@ -163,7 +163,7 @@ public:
     virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
             int optname, const void *optval, unsigned optlen);
 
-    /*  Get socket options
+    /** Get socket options
      *
      *  getsockopt allows an application to retrieve stack-specific options
      *  from the underlying stack using stack-specific level and option names,
@@ -180,6 +180,22 @@ public:
      */
     virtual nsapi_error_t getsockopt(nsapi_socket_t handle, int level, int optname,
             void *optval, unsigned *optlen);
+
+    /** Register callback for status reporting
+     *
+     *  The specified status callback function will be called on status changes
+     *  on the network. The parameters on the callback are the event type and
+     *  event-type dependent reason parameter.
+     *
+     *  @param status_cb The callback for status changes
+     */
+    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    virtual nsapi_connection_status_t get_connection_status() const;
 
 protected:
     /** Open a socket

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -187,6 +187,10 @@ public:
      *  on the network. The parameters on the callback are the event type and
      *  event-type dependent reason parameter.
      *
+     *  In ESP8266 the callback will be called when processing OOB-messages via
+     *  AT-parser. Do NOT call any ESP8266Interface -functions or do extensive
+     *  processing in the callback.
+     *
      *  @param status_cb The callback for status changes
      */
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);


### PR DESCRIPTION
AT instruction manual chapter 7 lists AT messages and 3 of those are used now for connection status tracking:
WIFI CONNECTED - ESP8266 station connected to an AP.
WIFI GOT IP - ESP8266 station got IP address.
WIFI DISCONNECT - ESP8266 station disconnected from an AP

https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf
