### PR TITLE
ESP8266 now clears socket buffer packets on reset and close

### DIFF
--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -291,6 +291,7 @@ private:
     void _oob_socket4_closed_handler();
     void _connection_status_handler();
     void _oob_socket_close_error();
+    void _clear_socket_packets(int id);
 
     char _ip_buffer[16];
     char _gateway_buffer[16];


### PR DESCRIPTION
After a board where the ESP8266 was connected to was reset, the ESP8266 send incoming packets from previous session to the board until reset AT command (AT+RST) was handled. Added clearing of the socket buffer after reset command.

Added clearing of packets for a socket during socket open() and close(). This ensured that when socket ID is reused, packets from previous session are not in the socket buffer.