### PR TITLE
Allow ESP8266 to provide default WifiInterface

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -575,3 +575,12 @@ nsapi_connection_status_t ESP8266Interface::get_connection_status() const
 {
     return _esp.get_connection_status();
 }
+
+#if MBED_CONF_ESP8266_PROVIDE_DEFAULT
+
+WiFiInterface *WiFiInterface::get_default_instance() {
+    static ESP8266Interface esp();
+    return &esp;
+}
+
+#endif

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -12,6 +12,10 @@
         "debug": {
             "help": "Enable debug logs",
             "value": false
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
         }
     },
     "target_overrides": {


### PR DESCRIPTION
ESP can be se to be default interface for the build by setting
"esp8266.provide-default": true, in mbed_app.json

@kjbracey-arm  Any opinions, is this the correct configuration option?