### PR TITLE
Feature tcp passive mode with AT firmware v1.7.0

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -37,10 +37,6 @@
 #endif
 #endif
 
-// Firmware version
-#define ESP8266_SDK_VERSION_MAJOR 2
-#define ESP8266_AT_VERSION_MAJOR 1
-
 ESP8266Interface::ESP8266Interface()
     : _esp(MBED_CONF_ESP8266_TX, MBED_CONF_ESP8266_RX, MBED_CONF_ESP8266_DEBUG, MBED_CONF_ESP8266_RTS, MBED_CONF_ESP8266_CTS),
       _initialized(false),
@@ -290,9 +286,13 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_get_firmware_ok()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
-        if (_disable_default_softap() == false) {
+        if (!_disable_default_softap()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
+        if (!_esp.cond_enable_tcp_passive_mode()) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+
         _initialized = true;
     }
     return NSAPI_ERROR_OK;


### PR DESCRIPTION
### Description
Enables TCP passive mode if ESP8266's AT firmware version is 1.7.0.0 or later. What this means that instead of ESP8266 sending data spontaneously over UART the data must be requested explicitly. No changes if older firmware is in use.

Reduces OOB processing when receiving UDP packets. This is something what should have been done already under PR #79.

### Pull request type
 
```
 [ ] Fix
 [ ] Refactor
 [ ] Target update
 [X] Functionality change
 [ ] Breaking change
```

