### PR TITLE
Makes possible to reset the modem if connection dropped

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -739,7 +739,6 @@ bool ESP8266::close(int id)
                     _clear_socket_packets(id);
                     _smutex.unlock();
                     // ESP8266 has a habit that it might close a socket on its own.
-                    //debug("ESP8266: socket %d already closed when calling close\n", id);
                     return true;
                 }
             } else {
@@ -872,8 +871,6 @@ void ESP8266::_oob_connection_status()
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_ENOMSG), \
                 "ESP8266::_oob_connection_status: network status timed out\n");
     }
-
-    //debug("ESP8266::_oob_connection_status: network state changed to WIFI \"%s\" (%d)\n", status, _connection_status);
 
     if(_connection_status_cb) {
         _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -294,11 +294,23 @@ public:
     }
 
     /**
-    * Attach a function to call whenever network state has changed
+    * Attach a function to call whenever network state has changed. Driver external
     *
     * @param func A pointer to a void function, or 0 to set as none
     */
     void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+
+    /**
+    * Attach a function to call whenever network state has changed. Driver internal
+    *
+    * @param func A pointer to a void function, or 0 to set as none
+    */
+    void attach_int(mbed::Callback<void()> status_cb);
+
+    template <typename T, typename M>
+    void attach_int(T *obj, M method) {
+        attach_int(Callback<void()>(obj, method));
+    }
 
     /**
      * Read default Wifi mode from flash
@@ -412,7 +424,8 @@ private:
 
     // Connection state reporting
     nsapi_connection_status_t _connection_status;
-    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb; // Application registered
+    Callback<void()> _conn_state_drv_cb; // ESP8266Interface registered
 };
 
 #endif

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -333,6 +333,7 @@ private:
 
     bool _disable_default_softap();
     void event();
+    void update_conn_state_cb();
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
     nsapi_error_t _startup(const int8_t wifi_mode);


### PR DESCRIPTION
### Description
Earlier internal state stayed consistent if connection drop happened by
calling disconnect(). Now spontaneous disconnect updates also the
drivers internal state.

**NOTE** This won't fix the issue that network status change gets processed only if application interacts with the driver by calling socket_recv() or socket_send(). OOB messages are processed still only when one of these functions is called.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

