### PR TITLE
Refactoring - organizing socket info etc

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -774,14 +774,9 @@ void ESP8266::sigio(Callback<void()> func)
     _serial.sigio(func);
 }
 
-void ESP8266::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+void ESP8266::attach(Callback<void()> status_cb)
 {
-    _connection_status_cb = status_cb;
-}
-
-void ESP8266::attach_int(mbed::Callback<void()> status_cb)
-{
-    _conn_state_drv_cb = status_cb;
+    _conn_stat_cb = status_cb;
 }
 
 bool ESP8266::_recv_ap(nsapi_wifi_ap_t *ap)
@@ -872,11 +867,8 @@ void ESP8266::_oob_connection_status()
                 "ESP8266::_oob_connection_status: network status timed out\n");
     }
 
-    if(_connection_status_cb) {
-        _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);
-    }
-
-    _conn_state_drv_cb();
+    MBED_ASSERT(_conn_stat_cb);
+    _conn_stat_cb();
 }
 
 int8_t ESP8266::default_wifi_mode()

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -387,7 +387,7 @@ private:
     // OOB message handlers
     void _oob_packet_hdlr();
     void _oob_connect_err();
-    void _oob_cipstart_already();
+    void _oob_conn_already();
     void _oob_socket0_closed();
     void _oob_socket1_closed();
     void _oob_socket2_closed();
@@ -416,7 +416,7 @@ private:
     struct _sock_info _sock_i[SOCKET_COUNT];
 
     // Connection state reporting
-    nsapi_connection_status_t _connection_status;
+    nsapi_connection_status_t _conn_status;
     Callback<void()> _conn_stat_cb; // ESP8266Interface registered
 };
 

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -294,22 +294,15 @@ public:
     }
 
     /**
-    * Attach a function to call whenever network state has changed. Driver external
+    * Attach a function to call whenever network state has changed.
     *
     * @param func A pointer to a void function, or 0 to set as none
     */
-    void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
-
-    /**
-    * Attach a function to call whenever network state has changed. Driver internal
-    *
-    * @param func A pointer to a void function, or 0 to set as none
-    */
-    void attach_int(mbed::Callback<void()> status_cb);
+    void attach(mbed::Callback<void()> status_cb);
 
     template <typename T, typename M>
-    void attach_int(T *obj, M method) {
-        attach_int(Callback<void()>(obj, method));
+    void attach(T *obj, M method) {
+        attach(mbed::Callback<void()>(obj, method));
     }
 
     /**
@@ -424,8 +417,7 @@ private:
 
     // Connection state reporting
     nsapi_connection_status_t _connection_status;
-    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb; // Application registered
-    Callback<void()> _conn_state_drv_cb; // ESP8266Interface registered
+    Callback<void()> _conn_stat_cb; // ESP8266Interface registered
 };
 
 #endif

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -46,14 +46,14 @@
 ESP8266Interface::ESP8266Interface()
     : _esp(MBED_CONF_ESP8266_TX, MBED_CONF_ESP8266_RX, MBED_CONF_ESP8266_DEBUG, MBED_CONF_ESP8266_RTS, MBED_CONF_ESP8266_CTS),
       _initialized(false),
-      _started(false)
+      _started(false),
+      _ap_sec(NSAPI_SECURITY_UNKNOWN)
 {
     memset(_ids, 0, sizeof(_ids));
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
     memset(_local_ports, 0, sizeof(_local_ports));
-    ap_sec = NSAPI_SECURITY_UNKNOWN;
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -65,14 +65,14 @@ ESP8266Interface::ESP8266Interface()
 ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
     : _esp(tx, rx, debug, rts, cts),
       _initialized(false),
-      _started(false)
+      _started(false),
+      _ap_sec(NSAPI_SECURITY_UNKNOWN)
 {
     memset(_ids, 0, sizeof(_ids));
     memset(_cbs, 0, sizeof(_cbs));
     memset(ap_ssid, 0, sizeof(ap_ssid));
     memset(ap_pass, 0, sizeof(ap_pass));
     memset(_local_ports, 0, sizeof(_local_ports));
-    ap_sec = NSAPI_SECURITY_UNKNOWN;
 
     _esp.sigio(this, &ESP8266Interface::event);
     _esp.set_timeout();
@@ -102,7 +102,7 @@ int ESP8266Interface::connect()
         return NSAPI_ERROR_NO_SSID;
     }
 
-    if (ap_sec != NSAPI_SECURITY_NONE) {
+    if (_ap_sec != NSAPI_SECURITY_NONE) {
         if (strlen(ap_pass) < ESP8266_PASSPHRASE_MIN_LENGTH) {
             return NSAPI_ERROR_PARAMETER;
         }
@@ -141,7 +141,7 @@ int ESP8266Interface::connect()
 
 int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
 {
-    ap_sec = security;
+    _ap_sec = security;
 
     if (!ssid) {
         return NSAPI_ERROR_PARAMETER;
@@ -157,7 +157,7 @@ int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_
         return NSAPI_ERROR_PARAMETER;
     }
 
-    if (ap_sec != NSAPI_SECURITY_NONE) {
+    if (_ap_sec != NSAPI_SECURITY_NONE) {
 
         if (!pass) {
             return NSAPI_ERROR_PARAMETER;

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -45,9 +45,9 @@
 #if defined MBED_CONF_ESP8266_TX && defined MBED_CONF_ESP8266_RX
 ESP8266Interface::ESP8266Interface()
     : _esp(MBED_CONF_ESP8266_TX, MBED_CONF_ESP8266_RX, MBED_CONF_ESP8266_DEBUG, MBED_CONF_ESP8266_RTS, MBED_CONF_ESP8266_CTS),
+      _ap_sec(NSAPI_SECURITY_UNKNOWN),
       _initialized(false),
       _started(false),
-      _ap_sec(NSAPI_SECURITY_UNKNOWN),
       _conn_stat(NSAPI_STATUS_DISCONNECTED),
       _conn_stat_cb(NULL)
 {
@@ -69,9 +69,9 @@ ESP8266Interface::ESP8266Interface()
 // ESP8266Interface implementation
 ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
     : _esp(tx, rx, debug, rts, cts),
+      _ap_sec(NSAPI_SECURITY_UNKNOWN),
       _initialized(false),
       _started(false),
-      _ap_sec(NSAPI_SECURITY_UNKNOWN),
       _conn_stat(NSAPI_STATUS_DISCONNECTED),
       _conn_stat_cb(NULL)
 {
@@ -271,11 +271,6 @@ bool ESP8266Interface::_get_firmware_ok()
     return true;
 }
 
-bool ESP8266Interface::_disable_default_softap()
-{
-    return _esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION);
-}
-
 nsapi_error_t ESP8266Interface::_init(void)
 {
     if (!_initialized) {
@@ -294,7 +289,7 @@ nsapi_error_t ESP8266Interface::_init(void)
         if (!_get_firmware_ok()) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
-        if (!_disable_default_softap()) {
+        if (!_esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION)) {
             return NSAPI_ERROR_DEVICE_ERROR;
         }
         if (!_esp.cond_enable_tcp_passive_mode()) {

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -323,14 +323,20 @@ private:
     static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
 
     ESP8266 _esp;
-    bool _ids[ESP8266_SOCKET_COUNT];
+
+    // Drivers's socket info
+    struct _sock_info {
+        bool open;
+        uint16_t sport;
+    };
+    struct _sock_info _sock_i[ESP8266_SOCKET_COUNT];
+
     int _initialized;
     int _started;
 
     char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     nsapi_security_t _ap_sec;
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
-    uint16_t _local_ports[ESP8266_SOCKET_COUNT];
 
     bool _disable_default_softap();
     void event();

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -329,7 +329,6 @@ private:
 
     char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
     nsapi_security_t _ap_sec;
-    uint8_t ap_ch;
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
     uint16_t _local_ports[ESP8266_SOCKET_COUNT];
 

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -320,6 +320,7 @@ protected:
 private:
     // AT layer
     ESP8266 _esp;
+    void update_conn_state_cb();
 
     // Credentials
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
@@ -353,9 +354,6 @@ private:
     // Connection state reporting to application
     nsapi_connection_status_t _conn_stat;
     Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb;
-
-    // Connection state from AT layer
-    void update_conn_state_cb();
 };
 
 #endif

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -328,7 +328,7 @@ private:
     int _started;
 
     char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
-    nsapi_security_t ap_sec;
+    nsapi_security_t _ap_sec;
     uint8_t ap_ch;
     char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
     uint16_t _local_ports[ESP8266_SOCKET_COUNT];

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -318,11 +318,16 @@ protected:
     }
 
 private:
+    // AT layer
+    ESP8266 _esp;
+
+    // Credentials
     static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
+    char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* The longest possible name; +1 for the \0 */
     static const int ESP8266_PASSPHRASE_MAX_LENGTH = 63; /* The longest allowed passphrase */
     static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
-
-    ESP8266 _esp;
+    char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1]; /* The longest possible passphrase; +1 for the \0 */
+    nsapi_security_t _ap_sec;
 
     // Drivers's socket info
     struct _sock_info {
@@ -331,28 +336,26 @@ private:
     };
     struct _sock_info _sock_i[ESP8266_SOCKET_COUNT];
 
+    // Driver's state
     int _initialized;
-    int _started;
-
-    char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
-    nsapi_security_t _ap_sec;
-    char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
-
-    bool _disable_default_softap();
-    void event();
-    void update_conn_state_cb();
     bool _get_firmware_ok();
     nsapi_error_t _init(void);
+    int _started;
     nsapi_error_t _startup(const int8_t wifi_mode);
 
+    //sigio
     struct {
         void (*callback)(void *);
         void *data;
     } _cbs[ESP8266_SOCKET_COUNT];
+    void event();
 
-    // Connection state reporting
+    // Connection state reporting to application
     nsapi_connection_status_t _conn_stat;
-    Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb; // Application registered
+    Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb;
+
+    // Connection state from AT layer
+    void update_conn_state_cb();
 };
 
 #endif

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -343,6 +343,10 @@ private:
         void (*callback)(void *);
         void *data;
     } _cbs[ESP8266_SOCKET_COUNT];
+
+    // Connection state reporting
+    nsapi_connection_status_t _conn_stat;
+    Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb; // Application registered
 };
 
 #endif

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -2,19 +2,19 @@
     "name": "esp8266",
     "config": {
         "tx": {
-            "help": "TX pin for serial connection. D1 assumed if Arduino Form Factor(AFF), needs to be set/overwritten otherwise",
+            "help": "TX pin for serial connection. D1 assumed if Arduino Form Factor, needs to be set/overwritten otherwise",
             "value": null
         },
         "rx": {
-            "help": "RX pin for serial connection. D0 assumed if Arduino Form Factor(AFF), needs to be set/overwritten otherwise",
+            "help": "RX pin for serial connection. D0 assumed if Arduino Form Factor, needs to be set/overwritten otherwise",
             "value": null
         },
         "rts": {
-            "help": "RTS pin for serial connection, defaults to Not Connected(NC)",
+            "help": "RTS pin for serial connection, defaults to Not Connected",
             "value": null
         },
         "cts": {
-            "help": "CTS pin for serial connection, defaults to Not Connected(NC)",
+            "help": "CTS pin for serial connection, defaults to Not Connected",
             "value": null
         },
         "debug": {


### PR DESCRIPTION
### Description
* Renames bunch of internal functions and drops superfluous ones along the way
* Organizes ESP8266Interface's socket info
* Drops unused member variable ap_sec
* Fixes layering of network status callbacks
* Cleans up the mbed_lib.json's help-sections

### Pull request type
    [] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change