### PR TITLE
AT firmware >= 1.7.0 - treat data as OOB

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -868,18 +868,20 @@ void ESP8266::_oob_busy()
 {
     char status[5];
     if (_parser.recv("%4[^\"]\n", status)) {
-        if (strcmp(status, " s...\n") == 0) {
-            ; //TODO maybe do something here, or not...
-        } else if (strcmp(status, "p...\n") == 0) {
-            ; //TODO maybe do something here, or not...
+        if (strcmp(status, "s...") == 0) {
+            tr_debug("busy s...");
+        } else if (strcmp(status, "p...") == 0) {
+            tr_debug("busy p...");
         } else {
+            tr_error("unrecognized busy state \'%s\'", status);
             MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_EBADMSG), \
-                       "ESP8266::_oob_busy: unrecognized busy state\n");
+                       "ESP8266::_oob_busy() unrecognized busy state\n");
         }
     } else {
         MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_CODE_ENOMSG), \
-                   "ESP8266::_oob_busy: AT timeout\n");
+                   "ESP8266::_oob_busy() AT timeout\n");
     }
+    _busy = true;
 }
 
 void ESP8266::_oob_connect_err()

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
+#include <string.h>
+#include <stdint.h>
+
 #include "ESP8266.h"
-#include "Callback.h"
-#include "mbed_error.h"
+#include "features/netsocket/nsapi_types.h"
 #include "mbed_trace.h"
-#include "nsapi_types.h"
 #include "PinNames.h"
+#include "platform/Callback.h"
+#include "platform/mbed_error.h"
 
 #define TRACE_GROUP  "ESPA" // ESP8266 AT layer
 
-#include <cstring>
-
 #define ESP8266_DEFAULT_BAUD_RATE   115200
 #define ESP8266_ALL_SOCKET_IDS      -1
+
+using namespace mbed;
 
 ESP8266::ESP8266(PinName tx, PinName rx, bool debug, PinName rts, PinName cts)
     : _sdk_v(-1, -1, -1),

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -421,6 +421,7 @@ private:
     bool _sock_already;
     bool _closed;
     bool _error;
+    bool _busy;
 
     // Modem's address info
     char _ip_buffer[16];

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -393,6 +393,7 @@ private:
         // data follows
     } *_packets, * *_packets_end;
     void _clear_socket_packets(int id);
+    int _sock_active_id;
 
     // Memory statistics
     size_t _heap_usage; // (Socket data buffer usage)
@@ -414,6 +415,7 @@ private:
     void _oob_socket_close_err();
     void _oob_watchdog_reset();
     void _oob_busy();
+    void _oob_tcp_data_hdlr();
 
     // OOB state variables
     int _connect_error;
@@ -433,6 +435,9 @@ private:
     struct _sock_info {
         bool open;
         nsapi_protocol_t proto;
+        char *tcp_data;
+        int32_t tcp_data_avbl; // Data waiting on modem
+        int32_t tcp_data_rcvd;
     };
     struct _sock_info _sock_i[SOCKET_COUNT];
 

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -17,11 +17,16 @@
 #ifndef ESP8266_H
 #define ESP8266_H
 
-#include "ATCmdParser.h"
-#include "Mutex.h"
-#include "nsapi_types.h"
-#include "rtos.h"
+#include <stdint.h>
+
+#include "rtos/Mutex.h"
 #include "drivers/UARTSerial.h"
+#include "platform/ATCmdParser.h"
+#include "platform/Callback.h"
+#include "platform/mbed_error.h"
+#include "features/netsocket/nsapi_types.h"
+#include "features/netsocket/WiFiAccessPoint.h"
+#include "PinNames.h"
 
 // Various timeouts for different ESP8266 operations
 #ifndef ESP8266_CONNECT_TIMEOUT
@@ -281,7 +286,7 @@ public:
     *
     * @param func A pointer to a void function, or 0 to set as none
     */
-    void sigio(Callback<void()> func);
+    void sigio(mbed::Callback<void()> func);
 
     /**
     * Attach a function to call whenever sigio happens in the serial
@@ -292,7 +297,7 @@ public:
     template <typename T, typename M>
     void sigio(T *obj, M method)
     {
-        sigio(Callback<void()>(obj, method));
+        sigio(mbed::Callback<void()>(obj, method));
     }
 
     /**
@@ -368,13 +373,13 @@ private:
     int32_t _recv_tcp_passive(int id, void *data, uint32_t amount, uint32_t timeout);
 
     // UART settings
-    UARTSerial _serial;
+    mbed::UARTSerial _serial;
     PinName _serial_rts;
     PinName _serial_cts;
-    Mutex _smutex; // Protect serial port access
+    rtos::Mutex _smutex; // Protect serial port access
 
     // AT Command Parser
-    ATCmdParser _parser;
+    mbed::ATCmdParser _parser;
 
     // Wifi scan result handling
     bool _recv_ap(nsapi_wifi_ap_t *ap);
@@ -432,7 +437,7 @@ private:
 
     // Connection state reporting
     nsapi_connection_status_t _conn_status;
-    Callback<void()> _conn_stat_cb; // ESP8266Interface registered
+    mbed::Callback<void()> _conn_stat_cb; // ESP8266Interface registered
 };
 
 #endif

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -19,14 +19,14 @@
 
 #include <stdint.h>
 
-#include "rtos/Mutex.h"
 #include "drivers/UARTSerial.h"
-#include "platform/ATCmdParser.h"
-#include "platform/Callback.h"
-#include "platform/mbed_error.h"
 #include "features/netsocket/nsapi_types.h"
 #include "features/netsocket/WiFiAccessPoint.h"
 #include "PinNames.h"
+#include "platform/ATCmdParser.h"
+#include "platform/Callback.h"
+#include "platform/mbed_error.h"
+#include "rtos/Mutex.h"
 
 // Various timeouts for different ESP8266 operations
 #ifndef ESP8266_CONNECT_TIMEOUT

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -40,6 +40,8 @@
 
 #define TRACE_GROUP  "ESPI" // ESP8266 Interface
 
+using namespace mbed;
+
 #if defined MBED_CONF_ESP8266_TX && defined MBED_CONF_ESP8266_RX
 ESP8266Interface::ESP8266Interface()
     : _esp(MBED_CONF_ESP8266_TX, MBED_CONF_ESP8266_RX, MBED_CONF_ESP8266_DEBUG, MBED_CONF_ESP8266_RTS, MBED_CONF_ESP8266_CTS),
@@ -612,7 +614,7 @@ void ESP8266Interface::event()
     }
 }
 
-void ESP8266Interface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+void ESP8266Interface::attach(Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
     _conn_stat_cb = status_cb;
 }

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-#include <cstring>
-#include "events/EventQueue.h"
-#include "events/mbed_shared_queues.h"
-#include "platform/Callback.h"
+#include <string.h>
+#include <stdint.h>
+
 #include "ESP8266.h"
 #include "ESP8266Interface.h"
-#include "mbed_debug.h"
+#include "events/EventQueue.h"
+#include "events/mbed_shared_queues.h"
+#include "features/netsocket/nsapi_types.h"
 #include "mbed_trace.h"
-#include "nsapi_types.h"
+#include "platform/Callback.h"
+#include "platform/mbed_debug.h"
 
 #ifndef MBED_CONF_ESP8266_DEBUG
 #define MBED_CONF_ESP8266_DEBUG false

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -21,6 +21,7 @@
 #include "ESP8266.h"
 #include "ESP8266Interface.h"
 #include "mbed_debug.h"
+#include "mbed_trace.h"
 #include "nsapi_types.h"
 
 #ifndef MBED_CONF_ESP8266_DEBUG
@@ -34,6 +35,8 @@
 #ifndef MBED_CONF_ESP8266_CTS
 #define MBED_CONF_ESP8266_CTS NC
 #endif
+
+#define TRACE_GROUP  "ESPI" // ESP8266 Interface
 
 #if defined MBED_CONF_ESP8266_TX && defined MBED_CONF_ESP8266_RX
 ESP8266Interface::ESP8266Interface()

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -291,13 +291,13 @@ bool ESP8266Interface::_get_firmware_ok()
     if (at_v.major < ESP8266_AT_VERSION_MAJOR) {
         debug("ESP8266: ERROR: AT Firmware v%d incompatible with this driver.", at_v.major);
         debug("Update at least to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\n", ESP8266_AT_VERSION_MAJOR);
-        return false;
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_UNSUPPORTED), "Too old AT firmware");
     }
     ESP8266::fw_sdk_version sdk_v = _esp.sdk_version();
     if (sdk_v.major < ESP8266_SDK_VERSION_MAJOR) {
         debug("ESP8266: ERROR: Firmware v%d incompatible with this driver.", sdk_v.major);
         debug("Update at least to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\n", ESP8266_SDK_VERSION_MAJOR);
-        return false;
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_DRIVER, MBED_ERROR_UNSUPPORTED), "Too old SDK firmware");
     }
 
     return true;

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -22,11 +22,11 @@
 #include "events/EventQueue.h"
 #include "events/mbed_shared_queues.h"
 #include "platform/Callback.h"
-#include "netsocket/nsapi_types.h"
-#include "netsocket/NetworkInterface.h"
-#include "netsocket/NetworkStack.h"
-#include "netsocket/WiFiAccessPoint.h"
-#include "netsocket/WiFiInterface.h"
+#include "features/netsocket/nsapi_types.h"
+#include "features/netsocket/NetworkInterface.h"
+#include "features/netsocket/NetworkStack.h"
+#include "features/netsocket/WiFiAccessPoint.h"
+#include "features/netsocket/WiFiInterface.h"
 
 #include "ESP8266.h"
 

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -376,7 +376,7 @@ private:
 
     // Connection state reporting to application
     nsapi_connection_status_t _conn_stat;
-    Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb;
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _conn_stat_cb;
 
     // Background OOB processing
     // Use global EventQueue

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -17,18 +17,16 @@
 #ifndef ESP8266_INTERFACE_H
 #define ESP8266_INTERFACE_H
 
-#include "mbed.h"
-
+#include "ESP8266/ESP8266.h"
 #include "events/EventQueue.h"
 #include "events/mbed_shared_queues.h"
-#include "platform/Callback.h"
-#include "features/netsocket/nsapi_types.h"
 #include "features/netsocket/NetworkInterface.h"
 #include "features/netsocket/NetworkStack.h"
+#include "features/netsocket/nsapi_types.h"
+#include "features/netsocket/SocketAddress.h"
 #include "features/netsocket/WiFiAccessPoint.h"
 #include "features/netsocket/WiFiInterface.h"
-
-#include "ESP8266.h"
+#include "platform/Callback.h"
 
 #define ESP8266_SOCKET_COUNT 5
 


### PR DESCRIPTION
To avoid AT recv() timeouts receiving data is handled as OOB. 

To get the performance improvement PR ARMmbed/mbed-os#8598 needs to be also taken into use
