### PR TITLE
Bugfix, TX and RX pin defaults provided if Arduino form factor

### DIFF
--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -23,16 +23,6 @@
 #include "mbed_debug.h"
 #include "nsapi_types.h"
 
-#ifdef TARGET_FF_ARDUINO
-#ifndef MBED_CONF_ESP8266_TX
-#define MBED_CONF_ESP8266_TX D1
-#endif
-
-#ifndef MBED_CONF_ESP8266_RX
-#define MBED_CONF_ESP8266_RX D0
-#endif
-#endif /* TARGET_FF_ARDUINO */
-
 #ifndef MBED_CONF_ESP8266_DEBUG
 #define MBED_CONF_ESP8266_DEBUG false
 #endif

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -32,6 +32,16 @@
 
 #define ESP8266_SOCKET_COUNT 5
 
+#ifdef TARGET_FF_ARDUINO
+#ifndef MBED_CONF_ESP8266_TX
+#define MBED_CONF_ESP8266_TX D1
+#endif
+
+#ifndef MBED_CONF_ESP8266_RX
+#define MBED_CONF_ESP8266_RX D0
+#endif
+#endif /* TARGET_FF_ARDUINO */
+
 /** ESP8266Interface class
  *  Implementation of the NetworkStack for the ESP8266
  */


### PR DESCRIPTION
Fixes a bug where default constructor declaration is not given even
if Arduino form factor shield is used. Required moving the defaults from
the ESP8266Interface source file to the header file.