### PR TITLE
Bugfix compile for targets without uart fc

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -151,6 +151,7 @@ struct ESP8266::fw_at_version ESP8266::at_version()
 bool ESP8266::stop_uart_hw_flow_ctrl(void)
 {
     bool done = true;
+#if DEVICE_SERIAL_FC
 
     if (_serial_rts != NC || _serial_cts != NC) {
         // Stop board's flow control
@@ -161,6 +162,7 @@ bool ESP8266::stop_uart_hw_flow_ctrl(void)
                && _parser.recv("OK\n");
     }
 
+#endif
     return done;
 }
 
@@ -168,6 +170,7 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
 {
     bool done = true;
 
+#if DEVICE_SERIAL_FC
     if (_serial_rts != NC && _serial_cts != NC) {
         // Start board's flow control
         _serial.set_flow_control(SerialBase::RTSCTS, _serial_rts, _serial_cts);
@@ -190,7 +193,11 @@ bool ESP8266::start_uart_hw_flow_ctrl(void)
 
         _serial.set_flow_control(SerialBase::CTS, NC, _serial_cts);
     }
-
+#else
+    if (_serial_rts != NC || _serial_cts != NC) {
+        done = false;
+    }
+#endif
     return done;
 }
 

--- a/ESP8266Interface.h
+++ b/ESP8266Interface.h
@@ -176,36 +176,12 @@ public:
      */
     using NetworkInterface::add_dns_server;
 
-    /** Set socket options
-     *
-     *  The setsockopt allow an application to pass stack-specific hints
-     *  to the underlying stack. For unsupported options,
-     *  NSAPI_ERROR_UNSUPPORTED is returned and the socket is unmodified.
-     *
-     *  @param handle   Socket handle
-     *  @param level    Stack-specific protocol level
-     *  @param optname  Stack-specific option identifier
-     *  @param optval   Option value
-     *  @param optlen   Length of the option value
-     *  @return         0 on success, negative error code on failure
+    /** @copydoc NetworkStack::setsockopt
      */
     virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
                                      int optname, const void *optval, unsigned optlen);
 
-    /** Get socket options
-     *
-     *  getsockopt allows an application to retrieve stack-specific options
-     *  from the underlying stack using stack-specific level and option names,
-     *  or to request generic options using levels from nsapi_socket_level_t.
-     *
-     *  For unsupported options, NSAPI_ERROR_UNSUPPORTED is returned
-     *  and the socket is unmodified.
-     *
-     *  @param level    Stack-specific protocol level or nsapi_socket_level_t
-     *  @param optname  Level-specific option name
-     *  @param optval   Destination for option value
-     *  @param optlen   Length of the option value
-     *  @return         0 on success, negative error code on failure
+    /** @copydoc NetworkStack::getsockopt
      */
     virtual nsapi_error_t getsockopt(nsapi_socket_t handle, int level, int optname,
                                      void *optval, unsigned *optlen);


### PR DESCRIPTION
To align with the in-tree version of this driver. Once this is accepted I'll tag the commit as v1.7.1.